### PR TITLE
Prepare deb package for ARMv6 devices (Raspberry Pi Zero W)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ script:
     - mendertesting/check_commits.sh
     # Check licenses
     - mendertesting/check_license.sh
+    # Build docker image
+    - docker build --tag=mender-dist-packages .
+    # Run docker container
+    - mkdir -p output && docker run -v $(pwd)/output:/output --rm mender-dist-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,38 @@
 FROM debian:stretch
 
-RUN dpkg --add-architecture armhf && \
-    apt-get update && apt-get install -y \
-    build-essential crossbuild-essential-armhf \
+RUN apt-get update && apt-get install -y \
+    build-essential \
     git wget \
-    debhelper devscripts \
-    liblzma-dev:armhf
+    debhelper devscripts
 
 # Versions to use
 ARG MENDER_VERSION=2.0.0b1
 ARG GOLANG_VERSION=1.11.5
 
-# Set cross-compiler
-ENV CC "arm-linux-gnueabihf-gcc"
+# To provide support for Raspberry Pi Zero W a toolchain tuned for ARMv6 architecture must be used.
+# https://tracker.mender.io/browse/MEN-2399
+# Assumes $(pwd) is /
+RUN wget -nc -q https://toolchains.bootlin.com/downloads/releases/toolchains/armv6-eabihf/tarballs/armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 \
+    && tar -xjf armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 \
+    && rm armv6-eabihf--glibc--stable-2018.11-1.tar.bz2
+ENV CROSS_COMPILE "arm-buildroot-linux-gnueabihf"
+ENV CC "$CROSS_COMPILE-gcc"
+ENV PATH "$PATH:/armv6-eabihf--glibc--stable-2018.11-1/bin"
 
 # Golang environment, for cross-compiling the Mender client
 RUN wget -q https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz
 ENV GOPATH "/root/go"
 ENV PATH "$PATH:/usr/local/go/bin"
+
+# Build liblzma from source
+RUN wget -q https://tukaani.org/xz/xz-5.2.4.tar.gz \
+    && tar -C /root -xzf xz-5.2.4.tar.gz \
+    && cd /root/xz-5.2.4 \
+    && ./configure --host=$CROSS_COMPILE --prefix=/root/xz-5.2.4/install \
+    && make \
+    && make install
+ENV LIBLZMA_INSTALL_PATH "/root/xz-5.2.4/install"
 
 # Prepare the mender client source
 RUN go get -d github.com/mendersoftware/mender

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -38,13 +38,6 @@ if [ ! -d "/output" ]; then
   show_help_and_exit
 fi
 
-#Print misc env variables for debug
-echo "WORKDIR="`pwd`
-echo "PATH="$PATH
-echo "CC="$CC
-echo "GOPATH="$GOPATH
-echo "version=$version"
-
 mkdir debian && mkdir debian/source
 
 #TODO: find a way to take this from the Changelog itself
@@ -64,7 +57,7 @@ Build-Depends: debhelper (>= 9)
 
 Package: mender
 Architecture: armhf
-Depends: \${shlibs:Depends}, \${misc:Depends}
+Depends: libc6 (>= 2.12), liblzma5 (>= 5.1)
 Description: mender client
  Mender is an open source over-the-air (OTA) software updater for embedded Linux devices.
 EOF
@@ -78,7 +71,8 @@ cat << EOF > debian/rules
 	dh \$@
 
 override_dh_auto_build:
-	env GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 make build
+	make CGO_CFLAGS="-I${LIBLZMA_INSTALL_PATH}/include" CGO_LDFLAGS="-L${LIBLZMA_INSTALL_PATH}/lib" \
+        CC=$CC GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 build
 
 override_dh_auto_test:
 	true
@@ -87,6 +81,12 @@ override_dh_systemd_enable:
 	true
 
 override_dh_systemd_start:
+	true
+
+override_dh_strip:
+	\${CROSS_COMPILE}-strip --remove-section=.comment --remove-section=.note debian/mender/usr/bin/mender
+
+override_dh_shlibdeps:
 	true
 
 EOF


### PR DESCRIPTION
Ported the toolchain change from mender-convert to the deb package, so
that we are consistent in the ARM support accross the mender offering.

Along the way:
* Build liblzma from source instead of using the Debian upstream pkg
* Hardcode deb package dependencies instead of using Debian helper
* Compile go code for ARM6 (to be consistent across mender products)
* Clean debug prints

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>