### PR TITLE
MEN-2419: Integration test for interactive install

### DIFF
--- a/debian/mender-client.dirs
+++ b/debian/mender-client.dirs
@@ -1,3 +1,5 @@
+/etc/mender
 /usr/share/mender
 /usr/share/doc/mender
 /usr/bin
+/usr/share/doc/mender-client

--- a/debian/postinst
+++ b/debian/postinst
@@ -12,7 +12,7 @@ if [ ! -f /etc/mender/mender.conf ]; then
         mender setup \
             --device-type unknown \
             --demo=false \
-            --hosted-mender \
+            --mender-professional \
             --tenant-token "Paste your Hosted Mender token here" \
             --update-poll 1800 \
             --inventory-poll 28800 \
@@ -23,8 +23,6 @@ if [ ! -f /etc/mender/mender.conf ]; then
         mender setup
     fi
 
-    # Initialize artifact_info; should be removed after MEN-2585
-    echo "artifact_name=unknown" > /etc/mender/artifact_info
 fi
 
 #DEBHELPER#

--- a/debian/postrm
+++ b/debian/postrm
@@ -4,7 +4,6 @@ set -e
 
 if [ "$1" == "purge" ]; then
     rm /etc/mender/mender.conf
-    rm -f /etc/mender/artifact_info
     rm -f /var/lib/mender/device_type
 fi
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -5,6 +5,7 @@ set -e
 if [ "$1" == "purge" ]; then
     rm /etc/mender/mender.conf
     rm -f /etc/mender/artifact_info
+    rm -f /var/lib/mender/device_type
 fi
 
 #DEBHELPER#

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,8 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	# All install targets except install-systemd
-	DESTDIR=debian/mender-client make install-bin install-identity-scripts install-inventory-scripts install-modules
+	DESTDIR=debian/mender-client make install-bin install-conf install-identity-scripts \
+	install-inventory-scripts install-modules install-examples
 
 override_dh_auto_test:
 	true

--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -21,10 +21,7 @@ import re
 from helpers import package_filename, upload_deb_package
 from mender_test_containers.helpers import *
 
-class TestPackageMenderClientDefaults():
-    """Tests instalation, setup, start, removal and purge of mender-client deb package with
-    in non-interactive method (i.e. default configuration).
-    """
+class PackageMenderClientChecker():
 
     expected_update_modules = ["deb", "directory", "rpm", "script", "single-file"]
     expected_inventory_files = ["mender-inventory-bootloader-integration",
@@ -35,6 +32,95 @@ class TestPackageMenderClientDefaults():
     expected_indentity_files = ["mender-device-identity"]
 
     expected_copyright_md5sum = "269720c1a5608250abd54a7818f369f6"
+
+    def check_mender_client_version(self, ssh_connection, mender_version, mender_version_deb):
+        result = ssh_connection.run('mender -version')
+        if mender_version == "master":
+            # For master, mender -version will print the short git hash. We can obtain this
+            # from the deb package version, which is something like: "0.0~git20191022.dade697-1"
+            m = re.match(r"0.0~git[0-9]+\.([a-z0-9]+)-1", mender_version_deb)
+            assert m is not None
+            assert m.group(1) in result.stdout
+        else:
+            assert mender_version in result.stdout
+
+    def check_installed_files(self, ssh_connection, device_type="unknown"):
+        ssh_connection.run('test -x /usr/bin/mender')
+        ssh_connection.run('test -d /usr/share/mender/modules/v3')
+        for module in self.expected_update_modules:
+            module_path = os.path.join("/usr/share/mender/modules/v3", module)
+            ssh_connection.run('test -x {mod}'.format(mod=module_path))
+        ssh_connection.run('test -d /usr/share/mender/modules/v3')
+        for inventory in self.expected_inventory_files:
+            inventory_path = os.path.join("/usr/share/mender/inventory", inventory)
+            ssh_connection.run('test -x {invent}'.format(invent=inventory_path))
+        for identity in self.expected_indentity_files:
+            identity_path = os.path.join("/usr/share/mender/identity", identity)
+            ssh_connection.run('test -x {ident}'.format(ident=identity_path))
+        ssh_connection.run('test -d /etc/mender')
+        ssh_connection.run('test -f /etc/mender/mender.conf')
+        ssh_connection.run('test -f /lib/systemd/system/mender-client.service')
+        ssh_connection.run('test -f /etc/systemd/system/multi-user.target.wants/mender-client.service')
+
+        # Device type and artifact_info
+        ssh_connection.run('test -f /var/lib/mender/device_type')
+        result = ssh_connection.run('cat /var/lib/mender/device_type')
+        assert "device_type={}".format(device_type) in result.stdout
+        ssh_connection.run('test -f /etc/mender/artifact_info')
+
+        # Northern.tech copyright file
+        ssh_connection.run('test -f /usr/share/doc/mender-client/copyright')
+        result = ssh_connection.run('md5sum /usr/share/doc/mender-client/copyright')
+        assert result.stdout.split(' ')[0] == self.expected_copyright_md5sum
+
+    def check_systemd_start_full_cycle(self, ssh_connection):
+        # Check first that mender process is running
+        result = ssh_connection.run('pgrep mender')
+        assert result.exited == 0
+
+        # Detect of a full cycle in 4 min timeout (~2 min to generate device keys + 30 secs full cycle)
+        start_time = time.time()
+        while time.time() - start_time < 4 * 60:
+            result = ssh_connection.run('sudo journalctl -u mender-client --no-pager')
+            if "State transition: authorize [Sync] -> authorize-wait [Idle]" in result.stdout:
+                break
+            time.sleep(10)
+
+        # Check correct boot
+        assert "Started Mender OTA update service." in result.stdout
+        assert "Loaded configuration file" in result.stdout
+        assert "No dual rootfs configuration present" in result.stdout
+
+        # Check transition Sync to Idle (one full cycle)
+        assert "authorize failed: transient error: authorization request failed" in result.stdout
+        assert "State transition: authorize [Sync] -> authorize-wait [Idle]" in result.stdout
+
+    def check_removed_files(self, ssh_connection, purge):
+        # Check first that mender process has been stopped
+        result = ssh_connection.run('pgrep mender', warn=True)
+        assert result.exited == 1
+
+        ssh_connection.run('test ! -f /usr/bin/mender')
+        ssh_connection.run('test ! -e /usr/share/mender')
+        ssh_connection.run('test ! -f /lib/systemd/system/mender-client.service')
+        ssh_connection.run('test ! -f /etc/systemd/system/multi-user.target.wants/mender-client.service')
+        ssh_connection.run('test -d /etc/mender')
+        ssh_connection.run('test -d /var/lib/mender/')
+        if purge:
+            ssh_connection.run('test ! -f /etc/mender/mender.conf')
+            ssh_connection.run('test ! -f /var/lib/mender/device_type')
+        else:
+            ssh_connection.run('test -f /etc/mender/mender.conf')
+            ssh_connection.run('test -f /var/lib/mender/device_type')
+
+        result = ssh_connection.run('sudo journalctl -u mender-client --no-pager')
+        assert "Stopping Mender OTA update service..." in result.stdout
+        assert "Stopped Mender OTA update service." in result.stdout
+
+class TestPackageMenderClientDefaults(PackageMenderClientChecker):
+    """Tests instalation, setup, start, removal and purge of mender-client deb package with
+    in non-interactive method (i.e. default configuration).
+    """
 
     @pytest.mark.usefixtures("setup_test_container")
     def test_install_configure_start(self, setup_tester_ssh_connection, mender_dist_packages_versions, mender_version):
@@ -47,85 +133,84 @@ class TestPackageMenderClientDefaults():
         assert "Unpacking mender-client (" + mender_dist_packages_versions["mender-client"] + ")" in result.stdout
         assert "Setting up mender-client (" + mender_dist_packages_versions["mender-client"] + ")" in result.stdout
 
-        result = setup_tester_ssh_connection.run('mender -version')
-        if mender_version == "master":
-            # For master, mender -version will print the short git hash. We can obtain this
-            # from the deb package version, which is something like: "0.0~git20191022.dade697-1"
-            m = re.match(r"0.0~git[0-9]+\.([a-z0-9]+)-1", mender_dist_packages_versions["mender-client"])
-            assert m is not None
-            assert m.group(1) in result.stdout
-        else:
-            assert mender_version in result.stdout
+        self.check_mender_client_version(setup_tester_ssh_connection, mender_version, mender_dist_packages_versions["mender-client"])
 
-        # Check installed files
-        setup_tester_ssh_connection.run('test -x /usr/bin/mender')
-        setup_tester_ssh_connection.run('test -d /usr/share/mender/modules/v3')
-        for module in self.expected_update_modules:
-            module_path = os.path.join("/usr/share/mender/modules/v3", module)
-            setup_tester_ssh_connection.run('test -x {mod}'.format(mod=module_path))
-        setup_tester_ssh_connection.run('test -d /usr/share/mender/modules/v3')
-        for inventory in self.expected_inventory_files:
-            inventory_path = os.path.join("/usr/share/mender/inventory", inventory)
-            setup_tester_ssh_connection.run('test -x {invent}'.format(invent=inventory_path))
-        for identity in self.expected_indentity_files:
-            identity_path = os.path.join("/usr/share/mender/identity", identity)
-            setup_tester_ssh_connection.run('test -x {ident}'.format(ident=identity_path))
-        setup_tester_ssh_connection.run('test -d /etc/mender')
-        setup_tester_ssh_connection.run('test -f /etc/mender/mender.conf')
-        setup_tester_ssh_connection.run('test -f /lib/systemd/system/mender-client.service')
-        setup_tester_ssh_connection.run('test -f /etc/systemd/system/multi-user.target.wants/mender-client.service')
+        self.check_installed_files(setup_tester_ssh_connection)
 
-        # Northern.tech copyright file
-        setup_tester_ssh_connection.run('test -f /usr/share/doc/mender-client/copyright')
-        result = setup_tester_ssh_connection.run('md5sum /usr/share/doc/mender-client/copyright')
-        assert result.stdout.split(' ')[0] == self.expected_copyright_md5sum
+        # Default setup expects ServerURL hosted.mender.io
+        result = setup_tester_ssh_connection.run('cat /etc/mender/mender.conf')
+        assert '"ServerURL": "https://hosted.mender.io"' in result.stdout
 
-        # Force key generation in advance, as this takes quite a while
-        # It returns error because the Tenant Token is invalid, but we don't care
-        setup_tester_ssh_connection.run('sudo mender -bootstrap || true')
-
-        # Give time to boot and go once over the full cycle (retry poll interval: 30s)
-        time.sleep(50)
-        result = setup_tester_ssh_connection.run('sudo journalctl -u mender-client --no-pager')
-
-        # Check correct boot
-        assert "Started Mender OTA update service." in result.stdout
-        assert "Loaded configuration file" in result.stdout
-        assert "No dual rootfs configuration present" in result.stdout
-
-        # Check transition Sync to Idle (one full cycle)
-        assert "authorize failed: transient error: authorization request failed" in result.stdout
-        assert "State transition: authorize [Sync] -> authorize-wait [Idle]" in result.stdout
+        self.check_systemd_start_full_cycle(setup_tester_ssh_connection)
 
     @pytest.mark.usefixtures("setup_test_container")
     def test_remove_stop(self, setup_tester_ssh_connection, mender_dist_packages_versions):
         result = setup_tester_ssh_connection.run('sudo dpkg -r mender-client')
         assert "Removing mender-client (" + mender_dist_packages_versions["mender-client"] + ")" in result.stdout
 
-        # Check files and directories
-        setup_tester_ssh_connection.run('test ! -f /usr/bin/mender')
-        setup_tester_ssh_connection.run('test ! -e /usr/share/mender')
-        setup_tester_ssh_connection.run('test ! -f /lib/systemd/system/mender-client.service')
-        setup_tester_ssh_connection.run('test ! -f /etc/systemd/system/multi-user.target.wants/mender-client.service')
-        setup_tester_ssh_connection.run('test -d /etc/mender')
-        setup_tester_ssh_connection.run('test -f /etc/mender/mender.conf')
-        setup_tester_ssh_connection.run('test -d /var/lib/mender/')
-        setup_tester_ssh_connection.run('test -f /var/lib/mender/device_type')
-
-        result = setup_tester_ssh_connection.run('sudo journalctl -u mender-client --no-pager')
-        assert "Stopping Mender OTA update service..." in result.stdout
-        assert "Stopped Mender OTA update service." in result.stdout
+        self.check_removed_files(setup_tester_ssh_connection, purge=False)
 
     @pytest.mark.usefixtures("setup_test_container")
     def test_purge(self, setup_tester_ssh_connection, mender_dist_packages_versions):
         result = setup_tester_ssh_connection.run('sudo dpkg -P mender-client')
         assert "Purging configuration files for mender-client (" + mender_dist_packages_versions["mender-client"] + ")" in result.stdout
 
-        # Check files and directories
-        setup_tester_ssh_connection.run('test -d /etc/mender')
-        setup_tester_ssh_connection.run('test ! -f /etc/mender/mender.conf')
-        setup_tester_ssh_connection.run('test -d /var/lib/mender/')
-        setup_tester_ssh_connection.run('test ! -f /var/lib/mender/device_type')
+        self.check_removed_files(setup_tester_ssh_connection, purge=True)
+
+class TestPackageMenderClientInteractive(PackageMenderClientChecker):
+    """Tests instalation, setup, start, removal and purge of mender-client deb package with
+    in interactive method (i.e. user navigates wizard via stdin).
+    """
+
+    @pytest.mark.usefixtures("setup_test_container")
+    def test_install_configure_start(self, setup_tester_ssh_connection, mender_dist_packages_versions, mender_version):
+        result = setup_tester_ssh_connection.run('uname -a')
+        assert "raspberrypi" in result.stdout
+
+        upload_deb_package(setup_tester_ssh_connection, mender_dist_packages_versions["mender-client"])
+
+        # Install the package using the following flow in the wizard:
+        # Device type (for example raspberrypi3-raspbian): rasbperrytest
+        # Confirm devicetype as rasbperrytest? [Y/n] y
+        # Are you connecting this device to Hosted Mender? [Y/n] n
+        # Do you want to run the client in demo mode? [Y/n] y
+        # Set the IP of the Mender Server: [127.0.0.1] 1.2.3.4
+        result = setup_tester_ssh_connection.run('sudo dpkg -i ' + package_filename(mender_dist_packages_versions["mender-client"]) + """ <<STDIN
+rasbperrytest
+y
+n
+y
+1.2.3.4
+STDIN""")
+
+        assert "Unpacking mender-client (" + mender_dist_packages_versions["mender-client"] + ")" in result.stdout
+        assert "Setting up mender-client (" + mender_dist_packages_versions["mender-client"] + ")" in result.stdout
+
+        self.check_mender_client_version(setup_tester_ssh_connection, mender_version, mender_dist_packages_versions["mender-client"])
+
+        self.check_installed_files(setup_tester_ssh_connection, "rasbperrytest")
+
+        # Demo setup expects ServerURL docker.mender.io with IP address in /etc/hosts
+        result = setup_tester_ssh_connection.run('cat /etc/mender/mender.conf')
+        assert '"ServerURL": "https://docker.mender.io"' in result.stdout
+        result = setup_tester_ssh_connection.run('cat /etc/hosts')
+        assert re.match(r".*1\.2\.3\.4\s*docker\.mender\.io.*", result.stdout, re.DOTALL) is not None
+
+        self.check_systemd_start_full_cycle(setup_tester_ssh_connection)
+
+    @pytest.mark.usefixtures("setup_test_container")
+    def test_remove_stop(self, setup_tester_ssh_connection, mender_dist_packages_versions):
+        result = setup_tester_ssh_connection.run('sudo dpkg -r mender-client')
+        assert "Removing mender-client (" + mender_dist_packages_versions["mender-client"] + ")" in result.stdout
+
+        self.check_removed_files(setup_tester_ssh_connection, purge=False)
+
+    @pytest.mark.usefixtures("setup_test_container")
+    def test_purge(self, setup_tester_ssh_connection, mender_dist_packages_versions):
+        result = setup_tester_ssh_connection.run('sudo dpkg -P mender-client')
+        assert "Purging configuration files for mender-client (" + mender_dist_packages_versions["mender-client"] + ")" in result.stdout
+
+        self.check_removed_files(setup_tester_ssh_connection, purge=True)
 
 class TestPackageMenderClientSystemd():
 
@@ -141,6 +226,10 @@ class TestPackageMenderClientSystemd():
         # Wait for the reboot to actually start before calling wait_for_container_boot
         time.sleep(10)
         wait_for_container_boot(setup_test_container.container_id)
+
+        # Check first that mender process is running
+        result = conn.run('pgrep mender')
+        assert result.exited == 0
 
         result = conn.run('sudo journalctl -u mender-client --no-pager')
 

--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -58,15 +58,16 @@ class PackageMenderClientChecker():
             identity_path = os.path.join("/usr/share/mender/identity", identity)
             ssh_connection.run('test -x {ident}'.format(ident=identity_path))
         ssh_connection.run('test -d /etc/mender')
+        ssh_connection.run('test -f /etc/mender/artifact_info')
         ssh_connection.run('test -f /etc/mender/mender.conf')
         ssh_connection.run('test -f /lib/systemd/system/mender-client.service')
         ssh_connection.run('test -f /etc/systemd/system/multi-user.target.wants/mender-client.service')
+        ssh_connection.run('test -f /usr/share/doc/mender-client/examples/demo.crt')
 
-        # Device type and artifact_info
+        # Device type
         ssh_connection.run('test -f /var/lib/mender/device_type')
         result = ssh_connection.run('cat /var/lib/mender/device_type')
         assert "device_type={}".format(device_type) in result.stdout
-        ssh_connection.run('test -f /etc/mender/artifact_info')
 
         # Northern.tech copyright file
         ssh_connection.run('test -f /usr/share/doc/mender-client/copyright')
@@ -104,14 +105,18 @@ class PackageMenderClientChecker():
         ssh_connection.run('test ! -e /usr/share/mender')
         ssh_connection.run('test ! -f /lib/systemd/system/mender-client.service')
         ssh_connection.run('test ! -f /etc/systemd/system/multi-user.target.wants/mender-client.service')
-        ssh_connection.run('test -d /etc/mender')
+        ssh_connection.run('test ! -f /usr/share/doc/mender-client/examples/demo.crt')
         ssh_connection.run('test -d /var/lib/mender/')
         if purge:
             ssh_connection.run('test ! -f /etc/mender/mender.conf')
             ssh_connection.run('test ! -f /var/lib/mender/device_type')
+            ssh_connection.run('test ! -f /etc/mender/artifact_info')
+            ssh_connection.run('test ! -d /etc/mender')
         else:
             ssh_connection.run('test -f /etc/mender/mender.conf')
             ssh_connection.run('test -f /var/lib/mender/device_type')
+            ssh_connection.run('test -f /etc/mender/artifact_info')
+            ssh_connection.run('test -d /etc/mender')
 
         result = ssh_connection.run('sudo journalctl -u mender-client --no-pager')
         assert "Stopping Mender OTA update service..." in result.stdout


### PR DESCRIPTION
```
commit 2244db2b5e68476cd31be622b7a9ae8f11e56788
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Oct 28 15:35:27 2019 +0100

    Clean-up device_type file on purge in postrm step.
    
    This file is created by mender setup in postinst step, so it should be
    cleaned up accordignly on purge in postrm step.
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit e531df5f7e9e7b1785cf3ffd9033f5272171e260
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Oct 28 15:40:32 2019 +0100

    Rework current tests to use the new package in non-intreactive mode
    
    This commit removes the extra configuration steps and the enable/start
    of systemd service, as these are now handled on the deb pacakge install
    and remove logic.
    
    The installation of the pacakge is done in non-interactive mode, meaning
    using the default configuration for the Mender client.
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit bf1a647cfe61aa9afbf6a2437c99ef453ef8672c
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Oct 28 16:46:23 2019 +0100

    Add new test for the interactive installation of the client package
    
    Refactor the current code into a base class so that boths cases
    (interactive and non interactive) can share all the device checks.
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit bed1e13bd159d237f36e526123796aea98940adb
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Tue Oct 29 16:41:12 2019 +0100

    Fixes in deb recipe to adapt to latest changes in mender master
    
    Basically:
    - Rename of parameter --hosted-mender to --mender professional
    - Partial restore of install-conf in Makefile (with artifact_info file)
    - Addition of demo certificate with install-examples Makefile target
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```