### PR TITLE
Fix tag detection regex to accept build tags

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -24,7 +24,7 @@ version=$(git describe --tags --exact-match 2>/dev/null || git log -1 --pretty=0
 
 # Select the correct Debian recipe according to the minor version of Mender
 debian_recipe="debian-master";
-if echo $version | egrep '^[1-9]+\.[1-9]+\.[1-9]+-1$'; then
+if echo $version | egrep '^[0-9]+\.[0-9]+\.[0-9](-build[0-9]+)?-1$'; then
     branch=$(echo $version | sed -E 's/\.[^.]+$/.x/')
     if [ -d "debian-${branch}" ]; then
         debian_recipe="debian-${branch}"


### PR DESCRIPTION
Fix tag detection regex to accept build tags, tags can either be like 1.2.3 or 1.2.3-build4.