### PR TITLE
Rename Hosted Mender setup flag and set default device type

### DIFF
--- a/debian-master/postinst
+++ b/debian-master/postinst
@@ -8,11 +8,13 @@ if [ ! -f /etc/mender/mender.conf ]; then
 
     # For non interactive installs, reproduce the default production
     # configuration with a dummy device type and tenant token.
+    DEVICE_TYPE=${DEVICE_TYPE:=$(cat /etc/hostname)}
     if [ "$DEBIAN_FRONTEND" == "noninteractive" ]; then
         mender setup \
-            --device-type unknown \
+            --quiet \
+            --device-type "${DEVICE_TYPE}" \
             --demo=false \
-            --mender-professional \
+            --hosted-mender \
             --tenant-token "Paste your Hosted Mender token here" \
             --update-poll 1800 \
             --inventory-poll 28800 \


### PR DESCRIPTION
Made device type default to hostname in postinstall script.

changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>