### PR TITLE
Fix acceptance tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-commits.yml'
+    file: '.gitlab-ci-check-commits-signoffs.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-license.yml'
   - project: 'Northern.tech/Mender/mendertesting'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,8 @@ variables:
   MENDER_VERSION: "master"
   S3_BUCKET_NAME: "mender"
   S3_BUCKET_SUBPATH: "dist-packages/debian"
+  # Set to true to skip tests (i.e. old Mender client build). See QA-123
+  SKIP_TESTS: "false"
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
@@ -30,10 +32,10 @@ build:
     paths:
       - output/*
 
-# The tests are not versionized: they will fail for old Mender deb packages
-# Allow failures to be able to publish the deb packages. Proper fix in QA-123
 test:acceptance:
-  allow_failure: true
+  except:
+    variables:
+      - $SKIP_TESTS == "true"
   stage: test
   image: docker:18-dind
   tags:

--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -180,7 +180,7 @@ class TestPackageMenderClientDefaults(PackageMenderClientChecker):
             mender_dist_packages_versions["mender-client"],
         )
 
-        self.check_installed_files(setup_tester_ssh_connection)
+        self.check_installed_files(setup_tester_ssh_connection, "raspberrypi")
 
         # Default setup expects ServerURL hosted.mender.io
         result = setup_tester_ssh_connection.run("cat /etc/mender/mender.conf")

--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -231,18 +231,19 @@ class TestPackageMenderClientInteractive(PackageMenderClientChecker):
             setup_tester_ssh_connection, mender_dist_packages_versions["mender-client"]
         )
 
-        # Install the package using the following flow in the wizard:
-        # Device type (for example raspberrypi3-raspbian): rasbperrytest
-        # Confirm devicetype as rasbperrytest? [Y/n] y
-        # Are you connecting this device to Hosted Mender? [Y/n] n
+        # Install the package using the following flow for "mender setup":
+        # ...
+        # Enter a name for the device type (e.g. raspberrypi3): [raspberrypi] raspberrytest
+        # Are you connecting this device to hosted.mender.io? [Y/n] n
         # Do you want to run the client in demo mode? [Y/n] y
         # Set the IP of the Mender Server: [127.0.0.1] 1.2.3.4
+        # Mender setup successfully.
+        # ...
         result = setup_tester_ssh_connection.run(
             "sudo dpkg -i "
             + package_filename(mender_dist_packages_versions["mender-client"])
             + """ <<STDIN
-rasbperrytest
-y
+raspberrytest
 n
 y
 1.2.3.4
@@ -268,7 +269,7 @@ STDIN"""
             mender_dist_packages_versions["mender-client"],
         )
 
-        self.check_installed_files(setup_tester_ssh_connection, "rasbperrytest")
+        self.check_installed_files(setup_tester_ssh_connection, "raspberrytest")
 
         # Demo setup expects ServerURL docker.mender.io with IP address in /etc/hosts
         result = setup_tester_ssh_connection.run("cat /etc/mender/mender.conf")


### PR DESCRIPTION
The tests have been broken for a while, but because we were accepting failures in the Pipeline job it went unnoticed. This PR fixes the specific issues and disallow the job to fail from now on (there is a alternative method to skip tests if required).

See individual commits.