### PR TITLE
Minor improvements around Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stretch
+ARG DEBIAN_VERSION=stretch
+FROM debian:$DEBIAN_VERSION
 
 RUN dpkg --add-architecture armhf && \
     dpkg --add-architecture arm64 && \

--- a/docker-mender-dist-packages
+++ b/docker-mender-dist-packages
@@ -20,7 +20,7 @@ IMAGE_NAME=mender-dist-packages-builder
 
 docker_build_args="--build-arg MENDER_VERSION=${MENDER_VERSION:master}"
 
-docker build --tag ${IMAGE_NAME} ${docker_build_args} .
+docker build --no-cache --tag ${IMAGE_NAME} ${docker_build_args} .
 
 mkdir -p output
 


### PR DESCRIPTION
* Add --no-cache to the Docker build command
The image shall fetch Mender upstream on each build, so add an explicit
flag to disable cache. Mainly to help local builds, does not affect CI.

* Parametrize Docker base image
So that eventually we can reuse the same Dockerfile to build packages
for different Debian versions.