### PR TITLE
QA-214: Publish a 'latest' Mender deb package

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,9 +68,9 @@ publish:s3:
     - build
   before_script:
     - apt update && apt install -yyq awscli
+    - deb_version=$(cat output/mender-client-deb-version)
   script:
     - echo "Publishing ${MENDER_VERSION} packages to S3"
-    - deb_version=$(cat output/mender-client-deb-version)
     # For master packages, the Debian version is "0.0~git[iso-date].[git-hash]-1" and we make a copy named "master" for GUI to use
     - for arch in amd64 arm64 armhf; do
         aws s3 cp output/mender-client_${deb_version}_${arch}.deb
@@ -86,3 +86,11 @@ publish:s3:
       done
   only:
     - master
+
+publish:s3:latest:
+  extends: publish:s3
+  only:
+    variables:
+      - $MENDER_VERSION =~ /[0-9]+\.[0-9]+\.[0-9]+/
+  before_script:
+    - deb_version=latest

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -39,7 +39,10 @@ build_packages() {
   dch --create -v ${version} --package mender-client "Release ${version}. See online docs for Changelog"
 
   # Native build (amd64)
-  dpkg-buildpackage -us -uc -b
+  dpkg-buildpackage \
+    --unsigned-source \
+    --unsigned-changes \
+    --build=binary
 
   # ARM 32bit build (custom toolchain to support ARMv6)
   CROSS_COMPILE="arm-buildroot-linux-gnueabihf" \
@@ -49,13 +52,19 @@ build_packages() {
                CGO_LDFLAGS="-L/usr/lib/arm-linux-gnueabihf/" \
                GOARCH=arm \
                GOARM=6 \
-               dpkg-buildpackage -aarmhf -us -uc -b
+               dpkg-buildpackage -aarmhf \
+               --unsigned-source \
+               --unsigned-changes \
+               --build=binary
 
   # ARM 64bit build (Debian toolchain)
   CROSS_COMPILE="aarch64-linux-gnu" \
                CC="$CROSS_COMPILE-gcc" \
                GOARCH=arm64 \
-               dpkg-buildpackage -aarm64 -us -uc -b
+               dpkg-buildpackage -aarm64 \
+               --unsigned-source \
+               --unsigned-changes \
+               --build=binary
 }
 
 copy_packages_to_output() {

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -14,10 +14,12 @@ EOF
   exit 1
 }
 
-if [ ! -d "/output" ]; then
-  echo "Error: /output directory doesn't exist"
-  show_help_and_exit
-fi
+verify_output_directory_exists() {
+  if [ ! -d "/output" ]; then
+    echo "Error: /output directory doesn't exist"
+    show_help_and_exit
+  fi
+}
 
 extract_client_version() {
   # Create a version from VCS. For master, generate something like 0.0~git20191022.dade697
@@ -80,6 +82,8 @@ copy_packages_to_output() {
 ##############
 # Run script #
 ##############
+
+verify_output_directory_exists
 
 extract_client_version
 

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -19,45 +19,61 @@ if [ ! -d "/output" ]; then
   show_help_and_exit
 fi
 
-# Create a version from VCS. For master, generate something like 0.0~git20191022.dade697
-version=$(git describe --tags --exact-match 2>/dev/null || git log -1 --pretty=0.0~git%cd.%h --date format:%Y%m%d)-1
+extract_client_version() {
+  # Create a version from VCS. For master, generate something like 0.0~git20191022.dade697
+  version=$(git describe --tags --exact-match 2>/dev/null || git log -1 --pretty=0.0~git%cd.%h --date format:%Y%m%d)-1
+}
 
-# Select the correct Debian recipe according to the minor version of Mender
-debian_recipe="debian-master";
-if echo $version | egrep '^[0-9]+\.[0-9]+\.[0-9](b[0-9]+)?(-build[0-9]+)?-1$'; then
+build_packages() {
+  # Select the correct Debian recipe according to the minor version of Mender
+  debian_recipe="debian-master";
+  if echo $version | egrep '^[0-9]+\.[0-9]+\.[0-9](b[0-9]+)?(-build[0-9]+)?-1$'; then
     branch=$(echo $version | sed -E 's/\.[^.]+$/.x/')
     if [ -d "debian-${branch}" ]; then
-        debian_recipe="debian-${branch}"
+      debian_recipe="debian-${branch}"
     fi
-fi
-mv $debian_recipe debian
+  fi
+  mv $debian_recipe debian
 
-#TODO: find a way to take this from the Changelog itself
-dch --create -v ${version} --package mender-client "Release ${version}. See online docs for Changelog"
+  #TODO: find a way to take this from the Changelog itself
+  dch --create -v ${version} --package mender-client "Release ${version}. See online docs for Changelog"
 
-# Native build (amd64)
-dpkg-buildpackage -us -uc -b
+  # Native build (amd64)
+  dpkg-buildpackage -us -uc -b
 
-# ARM 32bit build (custom toolchain to support ARMv6)
-CROSS_COMPILE="arm-buildroot-linux-gnueabihf" \
-CC="$CROSS_COMPILE-gcc" \
-PATH="$PATH:/armv6-eabihf--glibc--stable-2018.11-1/bin" \
-CGO_CFLAGS="-I/usr/include/arm-linux-gnueabihf/ -idirafter /usr/include/" \
-CGO_LDFLAGS="-L/usr/lib/arm-linux-gnueabihf/" \
-GOARCH=arm \
-GOARM=6 \
-dpkg-buildpackage -aarmhf -us -uc -b
+  # ARM 32bit build (custom toolchain to support ARMv6)
+  CROSS_COMPILE="arm-buildroot-linux-gnueabihf" \
+               CC="$CROSS_COMPILE-gcc" \
+               PATH="$PATH:/armv6-eabihf--glibc--stable-2018.11-1/bin" \
+               CGO_CFLAGS="-I/usr/include/arm-linux-gnueabihf/ -idirafter /usr/include/" \
+               CGO_LDFLAGS="-L/usr/lib/arm-linux-gnueabihf/" \
+               GOARCH=arm \
+               GOARM=6 \
+               dpkg-buildpackage -aarmhf -us -uc -b
 
-# ARM 64bit build (Debian toolchain)
-CROSS_COMPILE="aarch64-linux-gnu" \
-CC="$CROSS_COMPILE-gcc" \
-GOARCH=arm64 \
-dpkg-buildpackage -aarm64 -us -uc -b
+  # ARM 64bit build (Debian toolchain)
+  CROSS_COMPILE="aarch64-linux-gnu" \
+               CC="$CROSS_COMPILE-gcc" \
+               GOARCH=arm64 \
+               dpkg-buildpackage -aarm64 -us -uc -b
+}
 
-# Copy package files to /output
-for file in $(find ../ -maxdepth 1 -type f); do
-  cp ${file} /output
-done
+copy_packages_to_output() {
+  # Copy package files to /output
+  for file in $(find ../ -maxdepth 1 -type f); do
+    cp ${file} /output
+  done
+  # Echo the package version to /output
+  echo ${version} > /output/mender-client-deb-version
+}
 
-# Echo the package version to /output
-echo ${version} > /output/mender-client-deb-version
+
+##############
+# Run script #
+##############
+
+extract_client_version
+
+build_packages
+
+copy_packages_to_output


### PR DESCRIPTION
The two first commits are just refactoring.

The last one is more of a question:

* Should this be published separately, as an option (Like I have done here)?
* Or should it be published alongside every build the script does?

I'm not really sure what is the preferred option here.