### PR TITLE
[pipeline] Improve publish:s3:apt-repo script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,10 +103,21 @@ publish:s3:apt-repo:
     - aws s3 cp --recursive s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/dists dists
     - aws s3 cp --recursive s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/pool pool
   script:
-    # Include the build packages in stable or experimental
+    # If build from final tag, include in stable
+    - if echo "${MENDER_VERSION}" | egrep -q '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    -   for change_file in $(ls ${CI_PROJECT_DIR}/output/mender-client_*.changes); do
+    -     reprepro include stable $change_file
+    -   done
+    - fi
+    - if echo "${MENDER_SHELL_VERSION}" | egrep -q '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    -   for change_file in $(ls ${CI_PROJECT_DIR}/output/mender-shell_*.changes); do
+    -     reprepro include stable $change_file
+    -   done
+    - fi
+    # Include everything else to experimental. Allow failures to ignore wrong
+    # distribution (final tags) or to ignore checksum missmatches (master rebuilds)
     - for change_file in $(ls ${CI_PROJECT_DIR}/output/*.changes); do
-    -   reprepro include stable $change_file ||
-        reprepro include experimental $change_file
+    -   reprepro include experimental $change_file || true
     - done
     # Upload to bucket
     - aws s3 sync db s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/db


### PR DESCRIPTION
Check build variables to be more strict on the publish policy: only
attempt including packages in stable which come from final tags.

Similarly, relax criteria in experimental so that it can fail when
master packages get rebuilt (which will happen very often).

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>