### PR TITLE
APT repository: keep unreferenced files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,18 +105,18 @@ publish:s3:apt-repo:
     # If build from final tag, include in stable
     - if echo "${MENDER_VERSION}" | egrep -q '^[0-9]+\.[0-9]+\.[0-9]+$'; then
     -   for change_file in $(ls ${CI_PROJECT_DIR}/output/mender-client_*.changes); do
-    -     reprepro include stable $change_file
+    -     reprepro --keepunreferencedfiles include stable $change_file
     -   done
     - fi
     - if echo "${MENDER_SHELL_VERSION}" | egrep -q '^[0-9]+\.[0-9]+\.[0-9]+$'; then
     -   for change_file in $(ls ${CI_PROJECT_DIR}/output/mender-shell_*.changes); do
-    -     reprepro include stable $change_file
+    -     reprepro --keepunreferencedfiles include stable $change_file
     -   done
     - fi
     # Include everything else to experimental. Allow failures to ignore wrong
     # distribution (final tags) or to ignore checksum missmatches (master rebuilds)
     - for change_file in $(ls ${CI_PROJECT_DIR}/output/*.changes); do
-    -   reprepro include experimental $change_file || true
+    -   reprepro --keepunreferencedfiles include experimental $change_file || true
     - done
     # Upload to bucket
     - aws s3 sync db s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/db


### PR DESCRIPTION
So that we can download user specified versions from mender-convert or
possibly other scripts.