### PR TITLE
mender-shell: Set mender-client dependency to 2.4.2-git version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,6 @@ COPY recipes /recipes
 
 # Import GPG key, if set
 ARG GPG_KEY_BUILD=""
-RUN echo $GPG_KEY_BUILD
 RUN if [ -n "$GPG_KEY_BUILD" ]; then \
         echo "$GPG_KEY_BUILD" | gpg --import; \
     fi

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -47,7 +47,11 @@ get_deb_version() {
     if [ -z "${DEB_VERSION}" ]; then
       DEB_VERSION="0.0.0"
     fi
+    # Increment 1 on the bugfix number
+    DEB_VERSION="$(echo ${DEB_VERSION} | sed -E 's/([0-9]+\.[0-9]+\.)([0-9]+)/echo "\1$((\2+1))"/e')"
+    # Append git date and commit
     DEB_VERSION="${DEB_VERSION}$(git log -1 --pretty=~git%cd.%h --date format:%Y%m%d)"
+    # Append Debian suffix
     DEB_VERSION="${DEB_VERSION}-1"
   fi
 }

--- a/recipes/mender-shell/debian-master/control
+++ b/recipes/mender-shell/debian-master/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>= 9)
 
 Package: mender-shell
 Architecture: any
-Depends: libc6 (>= 2.12), libglib2.0-0 (>=2.50), mender-client (>=2.5.0)
+Depends: libc6 (>= 2.12), libglib2.0-0 (>=2.50), mender-client (>=2.4.2~git20201209.d4def09-1)
 Description: Mender Shell
  Mender Shell is a Mender add-on allowing to open remote interactive shell terminal sessions.


### PR DESCRIPTION
* [Dockerfile] Remove echo of private key
Probably a leftover from development debug.

* Bump bugfix version for master/experimental builds
So that 2.4.2~giti[...] evaluates as newer than 2.4.1 but still lower
than 2.4.2 (or 2.5.0).

* mender-shell: Set mender-client dependency to 2.4.2-git version
So that it can be installed in experimental distribution.
The specific version has been selected as what is mender master today,
so that it includes the recently merged DBus feature and the new
versioning scheme from mender-dist-packages (see 868b6b1).