### PR TITLE
[mender-client rules] Add install-dbus target

### DIFF
--- a/recipes/mender-client/debian-master/rules
+++ b/recipes/mender-client/debian-master/rules
@@ -7,10 +7,10 @@ override_dh_auto_build:
 	make CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" CC="${CC}" \
 	GOOS=linux CGO_ENABLED=1 build
 
+# All install targets except install-systemd
+install_targets = $(shell egrep ^install\-.*: Makefile | grep -v install-systemd | cut -d: -f1)
 override_dh_auto_install:
-	# All install targets except install-systemd
-	DESTDIR=debian/mender-client make install-bin install-conf install-identity-scripts \
-	install-inventory-scripts install-modules install-examples
+	DESTDIR=debian/mender-client make $(install_targets)
 
 override_dh_auto_test:
 	true


### PR DESCRIPTION
In a way that the recipe becomes future ready for more install-* kind of
targets.