### PR TITLE
[pipeline] Add lock around APT repository update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,6 +96,17 @@ publish:s3:apt-repo:
     - fi
     - echo "$GPG_PRIV_KEY_DIST" | gpg --import
     - echo "$GPG_PUB_KEY_BUILD" | gpg --import
+    # Lock the bucket to block concurrent jobs
+    - while true; do
+    -   if aws s3 ls s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/lock; then
+    -     echo "$S3_BUCKET_REPO_PATH locked, waiting..."
+    -     sleep 10
+    -     continue
+    -   fi
+    -   touch lock
+    -   aws s3 mv lock s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/lock
+    -   break
+    - done
     # Prepare repo from two S3 buckets
     - mkdir repo
     - cd repo
@@ -128,6 +139,8 @@ publish:s3:apt-repo:
     - aws s3 sync dists s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/dists
     - aws s3 ls --recursive s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/dists/ |
       awk '{cmd="aws s3api put-object-acl --acl public-read --bucket ${S3_BUCKET_NAME} --key "$4; system(cmd)}'
+  after_script:
+    - aws s3 rm s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/lock
 
 publish:s3:legacy:mender-client:
   stage: publish


### PR DESCRIPTION
When two pipelines run in parallel (which happens on releases) there is
a high change of corrupting the repository.

Prevent it by locking the S3 bucket that we are about to update.

Note that this is not atomic and there is a chance of forever block one
of the pipelines, in which case it will be killed by GitLab timeout. Not
a very high risk.