### PR TITLE
Work around when master is exactly on a tag name.

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -40,7 +40,7 @@ checkout_repo() {
 get_deb_version() {
   # Create a version from Git. For master, generate X.Y.Z~git20191022.dade697-1,
   # where X.Y.Z is latest tag (not necessarily matching git describe)
-  if git describe --tags --exact-match 2>/dev/null; then
+  if [ "$VERSION" != "master" ] && git describe --tags --exact-match 2>/dev/null; then
     DEB_VERSION="$(git describe --tags --exact-match)-1"
   else
     DEB_VERSION="$(git tag | egrep '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -rV | head -n1)"

--- a/tests/test_package_addons.py
+++ b/tests/test_package_addons.py
@@ -63,7 +63,6 @@ class TestPackageAddons:
         )
 
         # Check mender-configure version
-        result = setup_tester_ssh_connection.run("mender-connect version")
         if mender_connect_version == "master":
             # For master it will print the short git hash. We can obtain this from the deb
             # package version, which is something like: "0.0~git20191022.dade697-1"
@@ -72,8 +71,8 @@ class TestPackageAddons:
                 mender_dist_packages_versions["mender-connect"],
             )
             assert m is not None
-            assert m.group(1) in result.stdout
         else:
+            result = setup_tester_ssh_connection.run("mender-connect version")
             assert mender_connect_version in result.stdout
 
     def test_mender_configure(


### PR DESCRIPTION
If we have requested to build master in the build parameters, we want
a SHA-based package version, even if it matches the tag exactly. This
is also expected by our tests, which fail without this fix.

However, the reported version by the tool should be the tag name, if
it's possible. So testing for this when building master is wrong,
because it can be both a tag name and a SHA, depending on what is
built.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>