### PR TITLE
Support building mender-client 2.3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,9 @@ RUN wget -q https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz
 ENV GOPATH "/root/go"
 ENV PATH "$PATH:/usr/local/go/bin"
+# Support building mender-client 2.3.x, since it does not have go modules support
+# For newer clients with a go.mod file, this is a no-op however.
+ENV GO111MODULE auto
 
 # Copy the debian recipe(s)
 COPY recipes /recipes

--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -39,7 +39,6 @@ class PackageMenderClientChecker:
     def check_mender_client_version(
         self, ssh_connection, mender_version, mender_version_deb
     ):
-        result = ssh_connection.run("mender -version")
         if mender_version == "master":
             # For master, mender -version will print the short git hash. We can obtain this
             # from the deb package version, which is something like: "0.0~git20191022.dade697-1"
@@ -47,8 +46,8 @@ class PackageMenderClientChecker:
                 r"[0-9]+\.[0-9]+\.[0-9]+~git[0-9]+\.([a-z0-9]+)-1", mender_version_deb
             )
             assert m is not None
-            assert m.group(1) in result.stdout
         else:
+            result = ssh_connection.run("mender -version")
             assert mender_version in result.stdout
 
     def check_installed_files(self, ssh_connection, device_type="unknown"):


### PR DESCRIPTION
The older client branch has no go module support, and hence the build fails.

Simply use the GO111MODULE=auto option, to handle both setups seamlessly.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>