### PR TITLE
Remove the https:// prefix from the GOPATH

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -32,8 +32,8 @@ verify_script_arguments() {
 }
 
 checkout_repo() {
-  git clone $REPO_URL /root/go/src/$REPO_URL
-  cd /root/go/src/$REPO_URL
+  git clone $REPO_URL /root/go/src/${REPO_URL#https://}
+  cd /root/go/src/${REPO_URL#https://}
   git checkout $VERSION
 }
 


### PR DESCRIPTION
This removes the https:// prefix from the repository name when cloning the repository

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>