### PR TITLE
Append build revision to package versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,7 +147,7 @@ publish:s3:apt-repo:
     -   done
     - fi
     # Include everything else to experimental. Allow failures to ignore wrong
-    # distribution (final tags) or to ignore checksum missmatches (master rebuilds)
+    # distribution (final tags) or to ignore checksum mismatches (master rebuilds)
     - for change_file in $(ls ${CI_PROJECT_DIR}/output/*.changes); do
     -   reprepro --keepunreferencedfiles include experimental $change_file || true
     - done

--- a/docker-mender-dist-packages
+++ b/docker-mender-dist-packages
@@ -41,7 +41,8 @@ for arch in amd64 armhf arm64; do
             mender-client \
             https://github.com/mendersoftware/mender \
             ${MENDER_VERSION:-master} \
-            ${arch}
+            ${arch} \
+            ${CI_PIPELINE_ID:-LOCAL}
 
     # Build mender-connect deb package
     docker run --rm \
@@ -50,7 +51,8 @@ for arch in amd64 armhf arm64; do
             mender-connect \
             https://github.com/mendersoftware/mender-connect \
             ${MENDER_CONNECT_VERSION:-master} \
-            ${arch}
+            ${arch} \
+            ${CI_PIPELINE_ID:-LOCAL}
 
     # Build mender-configure deb package (Architecture: all, so build only once)
     if [ "${arch}" = "amd64" ]; then
@@ -60,7 +62,8 @@ for arch in amd64 armhf arm64; do
                 mender-configure \
                 https://github.com/mendersoftware/mender-configure-module \
                 ${MENDER_CONFIGURE_VERSION:-master} \
-                ${arch}
+                ${arch} \
+                ${CI_PIPELINE_ID:-LOCAL}
     fi
 
 done

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -22,13 +22,14 @@ verify_output_directory_exists() {
 }
 
 verify_script_arguments() {
-  if [ $# -ne 4 ]; then
+  if [ $# -ne 5 ]; then
     show_help_and_exit
   fi
   DEB_PACKAGE=$1
   REPO_URL=$2
   VERSION=$3
   ARCH=$4
+  BUILD_ID=$5
 }
 
 checkout_repo() {
@@ -38,8 +39,10 @@ checkout_repo() {
 }
 
 get_deb_version() {
-  # Create a version from Git. For master, generate X.Y.Z~git20191022.dade697-1,
-  # where X.Y.Z is latest tag (not necessarily matching git describe)
+  # Create a version from Git.
+  #  - For Git tags: X.Y.Z-1
+  #  - For master: X.Y.Z~git<commit-date>.<commit-sha>-1+b<BUILD_ID>
+  #     where X.Y.Z is latest tag (not necessarily matching git describe)
   if [ "$VERSION" != "master" ] && git describe --tags --exact-match 2>/dev/null; then
     DEB_VERSION="$(git describe --tags --exact-match)-1"
   else
@@ -53,6 +56,8 @@ get_deb_version() {
     DEB_VERSION="${DEB_VERSION}$(git log -1 --pretty=~git%cd.%h --date format:%Y%m%d)"
     # Append Debian suffix
     DEB_VERSION="${DEB_VERSION}-1"
+    # Append build number
+    DEB_VERSION="${DEB_VERSION}+b${BUILD_ID}"
   fi
 }
 

--- a/tests/test_dist_packages_versions.py
+++ b/tests/test_dist_packages_versions.py
@@ -19,8 +19,10 @@ import pytest
 
 
 def verify_package_version(version, deb_version):
-    # For master, expect something like: "0.0~git20191022.dade697-1"
-    master_version_re = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+~git[0-9]+\.([a-z0-9]+)-1")
+    # For master, expect something like: "0.0~git20191022.dade697-1+b279517265"
+    master_version_re = re.compile(
+        r"[0-9]+\.[0-9]+\.[0-9]+~git[0-9]+\.([a-z0-9]+)-1\+b([0-9]+|LOCAL)"
+    )
 
     if version == "master":
         m = master_version_re.match(deb_version)

--- a/tests/test_dist_packages_versions.py
+++ b/tests/test_dist_packages_versions.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import re
+
+import pytest
+
+
+def verify_package_version(version, deb_version):
+    # For master, expect something like: "0.0~git20191022.dade697-1"
+    master_version_re = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+~git[0-9]+\.([a-z0-9]+)-1")
+
+    if version == "master":
+        m = master_version_re.match(deb_version)
+        assert m is not None, "Cannot match %s" % deb_version
+    else:
+        assert deb_version == version + "-1"
+
+
+def test_versions(
+    mender_version,
+    mender_connect_version,
+    mender_configure_version,
+    mender_dist_packages_versions,
+):
+    verify_package_version(
+        mender_version, mender_dist_packages_versions["mender-client"]
+    )
+    verify_package_version(
+        mender_connect_version, mender_dist_packages_versions["mender-connect"]
+    )
+    verify_package_version(
+        mender_configure_version, mender_dist_packages_versions["mender-configure"]
+    )

--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -36,17 +36,8 @@ class PackageMenderClientChecker:
 
     expected_copyright_md5sum = "7fd64609fe1bce47db0e8f6e3cc6a11d"
 
-    def check_mender_client_version(
-        self, ssh_connection, mender_version, mender_version_deb
-    ):
-        if mender_version == "master":
-            # For master, mender -version will print the short git hash. We can obtain this
-            # from the deb package version, which is something like: "0.0~git20191022.dade697-1"
-            m = re.match(
-                r"[0-9]+\.[0-9]+\.[0-9]+~git[0-9]+\.([a-z0-9]+)-1", mender_version_deb
-            )
-            assert m is not None
-        else:
+    def check_mender_client_version(self, ssh_connection, mender_version):
+        if mender_version != "master":
             result = ssh_connection.run("mender -version")
             assert mender_version in result.stdout
 
@@ -184,11 +175,7 @@ class TestPackageMenderClientDefaults(PackageMenderClientChecker):
             in result.stdout
         )
 
-        self.check_mender_client_version(
-            setup_tester_ssh_connection,
-            mender_version,
-            mender_dist_packages_versions["mender-client"],
-        )
+        self.check_mender_client_version(setup_tester_ssh_connection, mender_version)
 
         self.check_installed_files(setup_tester_ssh_connection, "raspberrypi")
 
@@ -273,11 +260,7 @@ STDIN"""
             in result.stdout
         )
 
-        self.check_mender_client_version(
-            setup_tester_ssh_connection,
-            mender_version,
-            mender_dist_packages_versions["mender-client"],
-        )
+        self.check_mender_client_version(setup_tester_ssh_connection, mender_version)
 
         self.check_installed_files(setup_tester_ssh_connection, "raspberrytest")
 


### PR DESCRIPTION
Main commit is:

```
    Append build revision to package versions
    
    So that the same source (same git commit) can be rebuild and
    re-published on experimental on changes from mender-dist-packages
    repository.
```

And somewhat related:
```
    [test] Create explicit test for package versions
    
    After 83c1685, we are not really verifying the output of mender -version
    on the target for master builds; so move out this part into a separate
    explicit test and (once on it) verify all packages.
```