### PR TITLE
Revert "mender-shell: Set mender-client dependency to 2.4.2-git version"

### DIFF
--- a/recipes/mender-connect/debian-master/control
+++ b/recipes/mender-connect/debian-master/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9)
 
 Package: mender-connect
 Architecture: any
-Depends: libc6 (>= 2.12), libglib2.0-0 (>=2.50), mender-client (>=2.4.2~git20201209.d4def09-1)
+Depends: libc6 (>= 2.12), libglib2.0-0 (>=2.50), mender-client (>=2.5.0)
 Description: Mender Connect
  Mender Connect is a Mender add-on which enhances the Mender Client providing a bidirectional
  communication channel with the server. It supports the following features:


### PR DESCRIPTION
This reverts commit 53d7891b84234ac10d1e8e071644a489d8dc3266.

Not necessary anymore after the official 2.5.0 release.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>