### PR TITLE
Fix APT repo update for mender-client-dev package

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,10 +146,10 @@ publish:s3:apt-repo:
     -     reprepro --keepunreferencedfiles include stable $change_file
     -   done
     - fi
-    # Include everything else to experimental. Allow failures to ignore wrong
-    # distribution (final tags) or to ignore checksum mismatches (master rebuilds)
+    # Include everything else to experimental.
+    # Packages names are unique: we append build number
     - for change_file in $(ls ${CI_PROJECT_DIR}/output/*.changes); do
-    -   reprepro --keepunreferencedfiles include experimental $change_file || true
+    -   reprepro --keepunreferencedfiles include experimental $change_file
     - done
     # Upload to bucket
     - aws s3 sync db s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/db

--- a/docker-mender-dist-packages
+++ b/docker-mender-dist-packages
@@ -34,38 +34,53 @@ for arch in amd64 armhf arm64; do
                 .
     fi
 
-    # Build mender-client deb package
+    # Build the architecture specific binary packages (any)
+    # mender-client
     docker run --rm \
             --volume $(pwd)/output:/output \
             $IMAGE_NAME:cross-${arch} \
             mender-client \
+            any \
             https://github.com/mendersoftware/mender \
             ${MENDER_VERSION:-master} \
             ${arch} \
             ${CI_PIPELINE_ID:-LOCAL}
 
-    # Build mender-connect deb package
+    # mender-connect
     docker run --rm \
             --volume $(pwd)/output:/output \
             $IMAGE_NAME:cross-${arch} \
             mender-connect \
+            any \
             https://github.com/mendersoftware/mender-connect \
             ${MENDER_CONNECT_VERSION:-master} \
             ${arch} \
             ${CI_PIPELINE_ID:-LOCAL}
 
-    # Build mender-configure deb package (Architecture: all, so build only once)
-    if [ "${arch}" = "amd64" ]; then
-        docker run --rm \
-                --volume $(pwd)/output:/output \
-                $IMAGE_NAME:cross-${arch} \
-                mender-configure \
-                https://github.com/mendersoftware/mender-configure-module \
-                ${MENDER_CONFIGURE_VERSION:-master} \
-                ${arch} \
-                ${CI_PIPELINE_ID:-LOCAL}
-    fi
-
 done
+
+# Build the architecture independent binary packages (all)
+# mender-configure
+docker run --rm \
+        --volume $(pwd)/output:/output \
+        $IMAGE_NAME:cross-amd64 \
+        mender-configure \
+        all \
+        https://github.com/mendersoftware/mender-configure-module \
+        ${MENDER_CONFIGURE_VERSION:-master} \
+        amd64 \
+        ${CI_PIPELINE_ID:-LOCAL}
+
+# mender-client (-dev package)
+docker run --rm \
+        --volume $(pwd)/output:/output \
+        $IMAGE_NAME:cross-amd64 \
+        mender-client \
+        all \
+        https://github.com/mendersoftware/mender \
+        ${MENDER_VERSION:-master} \
+        amd64 \
+        ${CI_PIPELINE_ID:-LOCAL}
+
 
 sudo chown $(id -u):$(id -g) output/*

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -22,14 +22,15 @@ verify_output_directory_exists() {
 }
 
 verify_script_arguments() {
-  if [ $# -ne 5 ]; then
+  if [ $# -ne 6 ]; then
     show_help_and_exit
   fi
   DEB_PACKAGE=$1
-  REPO_URL=$2
-  VERSION=$3
-  ARCH=$4
-  BUILD_ID=$5
+  DEB_BUILD_TYPE=$2
+  REPO_URL=$3
+  VERSION=$4
+  ARCH=$5
+  BUILD_ID=$6
 }
 
 checkout_repo() {
@@ -113,7 +114,7 @@ build_packages() {
       # Native build (amd64)
       dpkg-buildpackage \
         ${sign_flags} \
-        --build=binary
+        --build=$DEB_BUILD_TYPE
       ;;
 
     armhf)
@@ -135,7 +136,7 @@ build_packages() {
                   GOARM=6 \
                   dpkg-buildpackage -aarmhf \
                   ${sign_flags} \
-                  --build=binary
+                  --build=$DEB_BUILD_TYPE
       ;;
 
     arm64)
@@ -146,7 +147,7 @@ build_packages() {
                   GOARCH=arm64 \
                   dpkg-buildpackage -aarm64 \
                   ${sign_flags} \
-                  --build=binary
+                  --build=$DEB_BUILD_TYPE
       ;;
   esac
 }


### PR DESCRIPTION
* [pipeline] Do not accept failures on publish experimental packages
    
    All packages are unique since fix in f742f1c, so this workaround is not
    needed anymore.
    
    Unfortunately, it has actually been hiding another issue.

* dpkg-buildpackage: Stop using --build=binary and let the caller specify
    
    According to its man page, --build=binary is alias for --build=any,all
    which resulted in the three `mender-client_..._<arch>.changes` files
    containing the checksum for mender-client-dev and eventually making
    reprepro fail when trying to upload the same package (-dev) twice!
    
    Use instead "any" on the for loop for the architectures, and explicitly
    pass "all" for the platform independent packages. This creates a
    dedicated change files (`..._all.changes`) for the mender-client with only
    the mender-client-dev checksum.
