### PR TITLE
Fix checksum issue for arch. independent packages.

### DIFF
--- a/docker-mender-dist-packages
+++ b/docker-mender-dist-packages
@@ -34,13 +34,21 @@ for arch in amd64 armhf arm64; do
                 .
     fi
 
+    if [ "$arch" = "amd64" ]; then
+        # For amd64, build both architecture dependent and independent packages.
+        BUILD_TYPE=binary
+    else
+        # For others, build only architecture dependent packages.
+        BUILD_TYPE=any
+    fi
+
     # Build the binary packages, including architecture specific ones (binary)
     # mender-client
     docker run --rm \
             --volume $(pwd)/output:/output \
             $IMAGE_NAME:cross-${arch} \
             mender-client \
-            binary \
+            $BUILD_TYPE \
             https://github.com/mendersoftware/mender \
             ${MENDER_VERSION:-master} \
             ${arch} \
@@ -51,7 +59,7 @@ for arch in amd64 armhf arm64; do
             --volume $(pwd)/output:/output \
             $IMAGE_NAME:cross-${arch} \
             mender-connect \
-            binary \
+            $BUILD_TYPE \
             https://github.com/mendersoftware/mender-connect \
             ${MENDER_CONNECT_VERSION:-master} \
             ${arch} \


### PR DESCRIPTION
We cannot build architecture independent packages for all
architectures, because they overwrite each other, invalidating the
checksums of already built buildinfo indexes. Instead, build them only
for amd64.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>