### PR TITLE
MEN-4759: install-mender.sh: Support installing commercial packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -347,6 +347,7 @@ publish:production:s3:scripts:install-mender-sh:
       - production
 
 publish:s3:mender-monitor:
+  stage: publish
   image: debian:buster
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -319,8 +319,6 @@ publish:s3:legacy:mender-client:latest:
 
 .publish-template:s3:scripts:install-mender-sh:
   stage: publish
-  dependencies:
-    - test:acceptance
   image: debian:buster
   before_script:
     - apt update && apt install -yyq awscli

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,18 @@ test:acceptance:
         fi
 
 
+.publish_helper_functions: &publish_helper_functions |
+  # Bash function to check if the string is a final tag
+  function is_final_tag () {
+    version="$1"
+    [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && return 0 || return $?
+  }
+  # Bash function to check if the string is a build tag
+  function is_build_tag () {
+    version="$1"
+    [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$-build[0-9]+$ ]] && return 0 || return $?
+  }
+
 publish:s3:apt-repo:
   stage: publish
   only:
@@ -147,16 +159,10 @@ publish:s3:apt-repo:
     - aws s3 cp --recursive s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/dists dists
     - aws s3 cp --recursive s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/pool pool
   script:
-    # Bash function to check if the string is a final tag
-    - |
-      function is_final_tag () {
-        version=$1
-        echo "${version}" | egrep -q '^[0-9]+\.[0-9]+\.[0-9]+$'
-        return $?
-      }
+    - *publish_helper_functions
     # Bash function to compare two semantic versions, returns: 0 (=), 1(>) or 2(<)
     #  * "master" always evaluates to greater than any other version
-    #  * "build" versions like 1.3.4-build for are evaluated as 1.2.3
+    #  * "build" versions like 1.2.3-build4 for are evaluated as 1.2.3
     # Original source: https://stackoverflow.com/a/4025065
     - |
       function vercomp () {
@@ -350,6 +356,17 @@ publish:s3:mender-monitor:
     - build
   before_script:
     - apt update && apt install -yyq awscli
+    - *publish_helper_functions
   script:
     - echo "Publishing mender-monitor version ${MENDER_MONITOR_VERSION} to s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_PRIVATE}/${MENDER_MONITOR_VERSION}/"
     - aws s3 cp output/mender-monitor*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_PRIVATE}/${MENDER_MONITOR_VERSION}/
+    # Make copies in known destinations to be consumed by get.mender.io script:
+    # * For "experimental" channel, we make a copy of the newest master package in the master directory
+    # * For "stable" channel, we make a copy in a separate "latest" subdirectory of the latest tagged version
+    # This needs to be reworked before Mender 3.2, see MEN-5029 for more details.
+    - if is_build_tag ${MENDER_MONITOR_VERSION} || [ "${MENDER_MONITOR_VERSION}" == "master" ]; then
+    -   aws s3 cp output/mender-monitor*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_PRIVATE}/master/mender-monitor_master-1_all.deb
+    - fi
+    - if is_final_tag ${MENDER_MONITOR_VERSION}; then
+    -   aws s3 cp output/mender-monitor*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_PRIVATE}/latest/mender-monitor_latest-1_all.deb
+    - fi

--- a/scripts/install-mender.sh
+++ b/scripts/install-mender.sh
@@ -1,22 +1,44 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
 CHANNEL="stable"
 
-AVAILABLE_COMPONENTS="mender-client \
+# Each available component shall be in only one of the lists below
+AVAILABLE_COMPONENTS="\
+mender-client \
 mender-configure \
 mender-configure-demo \
 mender-configure-timezone \
-mender-connect"
+mender-connect \
+mender-monitor \
+"
 
-DEFAULT_COMPONENTS="mender-client \
+DEFAULT_COMPONENTS="\
+mender-client \
 mender-configure \
-mender-connect"
+mender-connect \
+"
 
-DEMO_COMPONENTS="$AVAILABLE_COMPONENTS"
+DEMO_COMPONENTS="\
+mender-configure-demo \
+mender-configure-timezone \
+"
+
+COMMERCIAL_COMPONENTS="\
+mender-monitor \
+"
 
 SELECTED_COMPONENTS="$DEFAULT_COMPONENTS"
+
+# URL prefix from where to download commercial compoments
+# TODO: Update after MC-5726
+MENDER_COMMERCIAL_DOWNLOAD_URL="https://download.mender.io/content/hosted/"
+
+# URL path for the actual components, formatted by version
+declare -A COMMERCIAL_COMP_TO_URL_PATH_F=(
+  [mender-monitor]="mender-monitor/debian/%s/mender-monitor_%s-1_all.deb"
+)
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -36,14 +58,15 @@ Running the Mender installation script.
 
 usage() {
     echo "usage: install-mender.sh [-h] [-c channel] [component...]"
-    echo "  -h             print this help"
-    echo "  -c CHANNEL     channel: stable(default)|experimental"
-    echo "  --demo         use defaults appropriate for demo"
-    echo "  <component>    list of components to install"
+    echo "  -h, --help          print this help"
+    echo "  -c CHANNEL          channel: stable(default)|experimental"
+    echo "  --demo              use defaults appropriate for demo"
+    echo "  --commercial        install commercial components, requires --jwt-token"
+    echo "  --jwt-token TOKEN   Hosted Mender JWT token"
+    echo "  <component>         list of components to install"
     echo ""
     echo "Supported components (x = installed by default):"
-    for c in $AVAILABLE_COMPONENTS
-    do
+    for c in $AVAILABLE_COMPONENTS; do
         if echo "$DEFAULT_COMPONENTS" | egrep -q "(^| )$c( |\$)"; then
             echo -n " (x) "
         else
@@ -54,8 +77,7 @@ usage() {
 }
 
 is_known_component() {
-    for known in $DEFAULT_COMPONENTS
-    do
+    for known in $AVAILABLE_COMPONENTS; do
         if [ "$1" = "$known" ]; then
             return 0
         fi
@@ -64,17 +86,18 @@ is_known_component() {
 }
 
 parse_args() {
-    selected_components=""
+    local selected_components=""
+    local args_copy="$@"
     while [ $# -gt 0 ]
     do
         case $1 in
-            -h)
+            -h|--help)
                 usage
                 exit 0
                 ;;
             -c)
                 if [ -n "$2" ]; then
-                    CHANNEL=$2
+                    CHANNEL="$2"
                     shift
                 else
                     echo "ERROR: channel requires a non-empty option argument."
@@ -83,10 +106,35 @@ parse_args() {
                 fi
                 ;;
             --demo)
-                SELECTED_COMPONENTS="$DEMO_COMPONENTS"
+                SELECTED_COMPONENTS="$SELECTED_COMPONENTS $DEMO_COMPONENTS"
+                ;;
+            --commercial)
+                if [[ ! "$args_copy" == *"--jwt-token"* ]]; then
+                    echo "ERROR: commercial requires --jwt-token argument."
+                    echo "Aborting."
+                    exit 1
+                fi
+                SELECTED_COMPONENTS="$SELECTED_COMPONENTS $COMMERCIAL_COMPONENTS"
+                ;;
+            --jwt-token)
+                if [ -n "$2" ]; then
+                    JWT_TOKEN="$2"
+                    shift
+                else
+                    echo "ERROR: jwt-token requires a non-empty option argument."
+                    echo "Aborting."
+                    exit 1
+                fi
                 ;;
             *)
                 if is_known_component "$1"; then
+                    if echo "$COMMERCIAL_COMPONENTS" | egrep -q "(^| )$1( |\$)"; then
+                        if [[ ! "$args_copy" == *"--jwt-token"* ]]; then
+                            echo "ERROR: $1 requires --jwt-token argument."
+                            echo "Aborting."
+                            exit 1
+                        fi
+                    fi
                     selected_components="$selected_components $1 "
                 else
                     echo "Unsupported argument: \`$1\`"
@@ -105,8 +153,7 @@ parse_args() {
 
 print_components() {
     echo "  Selected components:"
-    for c in $SELECTED_COMPONENTS
-    do
+    for c in $SELECTED_COMPONENTS; do
         printf "\t%s\n" "$c"
     done
 }
@@ -152,16 +199,71 @@ add_repo() {
     echo "$repo" > /etc/apt/sources.list.d/mender.list
 }
 
-do_install() {
+do_install_open() {
+    # Filter out commercial components
+    local selected_components_open=""
+    for c in $SELECTED_COMPONENTS; do
+        if ! echo "$COMMERCIAL_COMPONENTS" | egrep -q "(^| )$c( |\$)"; then
+            selected_components_open="$selected_components_open $c"
+        fi
+    done
+
+    # Return if no open source components selected
+    if [ -z "$selected_components_open" ]; then
+        return
+    fi
+
+    echo "  Installing open source components from APT repository"
+
     apt-get update
     apt-get install -y \
        -o Dpkg::Options::="--force-confdef" \
        -o Dpkg::Options::="--force-confold" \
-       $SELECTED_COMPONENTS
+       $selected_components_open
+
+    echo "  Success! Please run \`mender setup\` to configure the client."
+}
+
+do_install_commercial() {
+    # Filter commercial components
+    local selected_components_commercial=""
+    for c in $SELECTED_COMPONENTS; do
+        if echo "$COMMERCIAL_COMPONENTS" | egrep -q "(^| )$c( |\$)"; then
+            selected_components_commercial="$selected_components_commercial $c"
+        fi
+    done
+
+    # Return if no commercial components selected
+    if [ -z "$selected_components_commercial" ]; then
+        return
+    fi
+
+    echo "  Installing commercial components from $MENDER_COMMERCIAL_DOWNLOAD_URL"
+
+    # Translate Debian "channel" into Mender version
+    if [ "$CHANNEL" = "experimental" ]; then
+        version="master"
+    else
+        version="latest"
+    fi
+
+    # Download deb packages
+    for c in $selected_components_commercial; do
+        url="$MENDER_COMMERCIAL_DOWNLOAD_URL$(printf ${COMMERCIAL_COMP_TO_URL_PATH_F[$c]} $version $version)"
+        curl -fLsS -H "Authorization: Bearer $JWT_TOKEN" -O "$url" ||
+                (echo ERROR: Cannot get $c from $url; exit 1)
+    done
+
+    # Install all of them at once and fallback to install missing dependencies
+    local deb_packages_glob=$(echo $selected_components_commercial | sed -e 's/ /*.deb /g; s/$/*.deb/')
+    dpkg --install $deb_packages_glob || apt-get -f -y install
+
+    # Check individually each package
+    for c in $selected_components_commercial; do
+        dpkg --status $c || (echo ERROR: $c could not be installed; exit 1)
+    done
 
     echo "  Success!"
-    echo "  Please run \`mender setup\` to configure the client."
-    exit 0
 }
 
 banner
@@ -169,4 +271,7 @@ init "$@"
 print_components
 get_deps
 add_repo
-do_install
+do_install_open
+do_install_commercial
+
+exit 0


### PR DESCRIPTION
MEN-4759: install-mender.sh: Support installing commercial packages
    
    New flag --commercial to toggle the closed deb packages. It is meant to
    be used only from Hosted Mender and requires --jwt-token argument.
    
    The commercial deb packages are downloaded directly using curl and
    installed using dpkg. Reworked a bit the existing lists of packages in
    the script to have more meaningful purposes.
    
    Other related changes:
    * install-mender.sh: Require bash, which is already required by Mender
      GUI during onboarding.
    * pipeline: Make master/stable copies of packages. This is a short term
      solution but required for the script to have well known URL paths
