### PR TITLE
MEN-4452: Support running mender setup with user specified args

### DIFF
--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -91,21 +91,11 @@ def check_installed(conn, pkg, installed=True):
 
 @pytest.mark.usefixtures("script_server")
 class TestInstallMenderScript:
-    def _get_localhost_ip(self, setup_tester_ssh_connection):
-        """We need to access the toplevel host's port to curl the script.
-        'localhost' of course doesn't work, but qemu runs on docker in 'net=host' mode,
-        so the host's address is simply the default route.
-        """
-        result = setup_tester_ssh_connection.run(
-            "ip route | grep default | awk '{print $3}'"
-        )
-        return result.stdout.strip()
-
     @pytest.mark.parametrize("channel", ["", "stable", "experimental"])
     def test_default(
         self, generic_debian_container, channel,
     ):
-        """Default, no arg install installs mender-client and mender-connect (stable)."""
+        """Default, no arg install installs mender-client and add-ons (stable)."""
 
         if channel != "":
             channel = "-c " + channel

--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -172,7 +172,7 @@ class TestInstallMenderScript:
 
 @pytest.mark.usefixtures("script_server")
 class TestInstallMenderScriptRaspberryOS:
-    def test_default(
+    def test_raspbian_default(
         self, setup_tester_ssh_connection_f,
     ):
         # We need to access the toplevel host's port from QUEMU to curl the script.

--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -119,9 +119,38 @@ class TestInstallMenderScript:
             f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s -- unknown",
             warn=True,
         )
-
         assert res.returncode == 1
         assert "Unsupported argument: `unknown`" in res.stdout.decode()
+
+    def test_default_setup_mender(
+        self, generic_debian_container,
+    ):
+        """Pass mender setup args, should be propagated"""
+
+        generic_debian_container.run(
+            f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s -- -- --demo --device-type cool-device --hosted-mender --tenant-token my-secret-token"
+        )
+
+        result = generic_debian_container.run("cat /etc/mender/mender.conf")
+        assert '"ServerURL": "https://hosted.mender.io"' in result.stdout.decode()
+
+        result = generic_debian_container.run("cat /var/lib/mender/device_type")
+        assert result.stdout.decode() == "device_type=cool-device"
+
+        result = generic_debian_container.run("cat /etc/mender/mender-connect.conf")
+        assert '"User": "nobody"' in result.stdout.decode()
+
+    def test_default_setup_addons(
+        self, generic_debian_container,
+    ):
+        """Setup for add-ons (passing --demo)"""
+
+        generic_debian_container.run(
+            f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s -- --demo"
+        )
+
+        result = generic_debian_container.run("cat /etc/mender/mender-connect.conf")
+        assert '"User": "root"' in result.stdout.decode()
 
     def test_client(
         self, generic_debian_container,


### PR DESCRIPTION
    This gives the opportunity to the Mender GUI to offload the setup
    details to the install script.
    
    Two main changes:
    * Run mender setup with args passed after `--` marker.
    * Configure mender-connect for RPi on demo mode.
