### PR TITLE
MEN-5075: install-mender.sh: Fix script when not using --demo

### DIFF
--- a/scripts/install-mender.sh
+++ b/scripts/install-mender.sh
@@ -30,6 +30,7 @@ mender-monitor \
 "
 
 SELECTED_COMPONENTS="$DEFAULT_COMPONENTS"
+DEMO="0"
 
 # URL prefix from where to download commercial compoments
 MENDER_COMMERCIAL_DOWNLOAD_URL="https://downloads.customer.mender.io/content/hosted/"


### PR DESCRIPTION
If DEMO is not defined, the script would fail with:
`line 298: [: : integer expression expected`