### PR TITLE
GitLab intermittent networking fix: FF_NETWORK_PER_BUILD env var

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,8 @@ variables:
   TEST_MENDER_DIST_PACKAGES: "true"
   # Whether to publish packages automatically - they can always be published manually
   PUBLISH_MENDER_DIST_PACKAGES_AUTOMATIC: "false"
+  # Workaround for GitLab intermittent networking
+  FF_NETWORK_PER_BUILD: 1
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'


### PR DESCRIPTION
Using workaround #1 from https://gitlab.com/gitlab-com/gl-infra/production/-/issues/5590