### PR TITLE
mender-deb-package: Modify logic to detect private repo URL

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -37,7 +37,7 @@ verify_script_arguments() {
 checkout_repo_clean_local_path() {
   local -r repo_url="$1"
   local repo_path="${repo_url#https://}"
-  if [[ -n "${MENDER_PRIVATE_REPO_ACCESS_USER}" ]]; then
+  if [[ "$repo_url" == *"${MENDER_PRIVATE_REPO_ACCESS_USER:-none}"* ]]; then
     repo_path="${REPO_URL//${MENDER_PRIVATE_REPO_ACCESS_USER}:*@/}"
   fi
   echo "${repo_path}"


### PR DESCRIPTION
After the rework from 3eea53c, MENDER_PRIVATE_REPO_ACCESS_USER is
defined for all calls to mender-deb-package, so this if block needs to
be a bit smarter to only activate when it is actually in use (iow when
the user string is in the repository URL).