### PR TITLE
mender-deb-package: Amend version increment for "master" packages

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -62,8 +62,8 @@ get_deb_version() {
     if [ -z "${DEB_VERSION}" ]; then
       DEB_VERSION="0.0.0"
     fi
-    # Increment 1 on the minor number
-    DEB_VERSION="$(echo ${DEB_VERSION} | sed -E 's/([0-9]+\.)([0-9]+)(\.[0-9]+)/echo "\1$((\2+1))\3"/e')"
+    # Increment 1 on the minor number and set to 0 bugfix version
+    DEB_VERSION="$(echo ${DEB_VERSION} | sed -E 's/([0-9]+\.)([0-9]+)\.[0-9]+/echo "\1$((\2+1))\.0"/e')"
     # Append git date and commit
     DEB_VERSION="${DEB_VERSION}$(git log -1 --pretty=~git%cd.%h --date format:%Y%m%d)"
     # Append Debian suffix


### PR DESCRIPTION
With only increasing minor, we risk that for a component with last
version `1.2.3` the next master is `1.3.3` which evaluates higher that
the next final release `1.3.0`...

Amends commit 99885d9.