### PR TITLE
Fix TestPackageMenderClientInteractive after introducing a new step

### DIFF
--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -270,6 +270,7 @@ raspberrytest
 n
 y
 1.2.3.4
+y
 STDIN"""
         )
 


### PR DESCRIPTION
After https://github.com/mendersoftware/mender/pull/873 there is an
extra step in the interactive dialog.