### PR TITLE
Update golang version to latest 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN if [ "${ARCH}" = "arm64" ]; then \
     fi
 
 # Golang environment, for cross-compiling the Mender client
-ARG GOLANG_VERSION=1.14.7
+ARG GOLANG_VERSION=1.17.6
 RUN wget -q https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz
 ENV GOPATH "/root/go"


### PR DESCRIPTION
So that we can build mender-gateway and are a bit more future proofed.