### PR TITLE
MEN-5390: Fix (again) the binary symlinks for mender-monitor

### DIFF
--- a/recipes/mender-monitor/debian-master/rules
+++ b/recipes/mender-monitor/debian-master/rules
@@ -10,3 +10,6 @@ override_dh_auto_install:
 
 override_dh_missing:
 	dh_missing --fail-missing
+
+override_dh_link:
+	true


### PR DESCRIPTION
We fixed this once, see cad433a, but by mistake the fix got lost when we
duplicated the recipes for mender-monitor > 1.0.x