### PR TITLE
debian-2.4.x: Add libffi6 as a depency for the client

### DIFF
--- a/recipes/mender-client/debian-2.4.x/control
+++ b/recipes/mender-client/debian-2.4.x/control
@@ -8,6 +8,6 @@ Build-Depends: debhelper (>= 9)
 Package: mender-client
 Conflicts: mender
 Architecture: any
-Depends: libc6 (>= 2.12), libglib2.0-0 (>=2.50), liblzma5 (>= 5.1), libssl1.1 (>= 1.1)
+Depends: libc6 (>= 2.12), libglib2.0-0 (>=2.50), liblzma5 (>= 5.1), libssl1.1 (>= 1.1), libffi6 (>= 3.2)
 Description: Mender client
  Mender is an open source over-the-air (OTA) software updater for embedded Linux devices.


### PR DESCRIPTION
Porting fix 1d21cab from master recipe to the still supported versions
of mender-client.