### PR TITLE
pipeline: fixes for bugfix release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -361,19 +361,20 @@ publish:production:s3:scripts:install-mender-sh:
     # Make copies in known destinations to be consumed by get.mender.io script:
     # * For "experimental" channel, we make a copy of the newest master package in the master directory
     # * For "stable" channel, we make a copy in a separate "latest" subdirectory of the latest tagged version
-    # This can to be reworked for better maintainability, see MEN-5029 for more details.
-    - if is_build_tag ${MENDER_MONITOR_VERSION} || [ "${MENDER_MONITOR_VERSION}" == "master" ]; then
-    -   aws s3 cp output/commercial/mender-monitor_*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/master/mender-monitor_master-1_all.deb
-    -   if test -f output/commercial/mender-monitor-demo*.deb; then
-    -     aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/master/mender-monitor-demo_master-1_all.deb
-    -  fi
-    - fi
-    - if is_final_tag ${MENDER_MONITOR_VERSION}; then
-    -   aws s3 cp output/commercial/mender-monitor_*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/latest/mender-monitor_latest-1_all.deb
-    -   if test -f output/commercial/mender-monitor-demo*.deb; then
-    -     aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/latest/mender-monitor-demo_latest-1_all.deb
-    -   fi
-    - fi
+
+    # Needs to be reworked, see MEN-5029
+    # - if is_build_tag ${MENDER_MONITOR_VERSION} || [ "${MENDER_MONITOR_VERSION}" == "master" ]; then
+    # -   aws s3 cp output/commercial/mender-monitor_*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/master/mender-monitor_master-1_all.deb
+    # -   if test -f output/commercial/mender-monitor-demo*.deb; then
+    # -     aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/master/mender-monitor-demo_master-1_all.deb
+    # -  fi
+    # - fi
+    # - if is_final_tag ${MENDER_MONITOR_VERSION}; then
+    # -   aws s3 cp output/commercial/mender-monitor_*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/latest/mender-monitor_latest-1_all.deb
+    # -   if test -f output/commercial/mender-monitor-demo*.deb; then
+    # -     aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/latest/mender-monitor-demo_latest-1_all.deb
+    # -   fi
+    # - fi
 
 publish:s3:mender-monitor:manual:
   when: manual
@@ -400,17 +401,18 @@ publish:s3:mender-monitor:automatic:
     # Make copies in known destinations to be consumed by get.mender.io script:
     # * For "experimental" channel, we make a copy of the newest master package in the master directory
     # * For "stable" channel, we make a copy in a separate "latest" subdirectory of the latest tagged version
-    # This can to be reworked for better maintainability, see MEN-5029 for more details.
-    - if is_build_tag ${MENDER_GATEWAY_VERSION} || [ "${MENDER_GATEWAY_VERSION}" == "master" ]; then
-    -   for arch in amd64 arm64 armhf; do
-    -     aws s3 cp output/commercial/mender-gateway*_${arch}.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_GATEWAY}/master/mender-gateway_master-1_${arch}.deb 
-    -  done
-    - fi
-    - if is_final_tag ${MENDER_GATEWAY_VERSION}; then
-    -   for arch in amd64 arm64 armhf; do
-    -     aws s3 cp output/commercial/mender-gateway*_${arch}.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_GATEWAY}/latest/mender-gateway_latest-1_${arch}.deb
-    -   done
-    - fi
+
+    # Needs to be reworked, see MEN-5029
+    # - if is_build_tag ${MENDER_GATEWAY_VERSION} || [ "${MENDER_GATEWAY_VERSION}" == "master" ]; then
+    # -   for arch in amd64 arm64 armhf; do
+    # -     aws s3 cp output/commercial/mender-gateway*_${arch}.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_GATEWAY}/master/mender-gateway_master-1_${arch}.deb
+    # -  done
+    # - fi
+    # - if is_final_tag ${MENDER_GATEWAY_VERSION}; then
+    # -   for arch in amd64 arm64 armhf; do
+    # -     aws s3 cp output/commercial/mender-gateway*_${arch}.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_GATEWAY}/latest/mender-gateway_latest-1_${arch}.deb
+    # -   done
+    # - fi
 
 publish:s3:mender-gateway:manual:
   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -354,19 +354,25 @@ publish:production:s3:scripts:install-mender-sh:
   script:
     - echo "Publishing mender-monitor version ${MENDER_MONITOR_VERSION} to s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/${MENDER_MONITOR_VERSION}/"
     - aws s3 cp output/commercial/mender-monitor_*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/${MENDER_MONITOR_VERSION}/
-    - echo "Publishing mender-monitor-demo version ${MENDER_MONITOR_VERSION} to s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/${MENDER_MONITOR_VERSION}/"
-    - aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/${MENDER_MONITOR_VERSION}/
+    - if test -f output/commercial/mender-monitor-demo*.deb; then
+    -   echo "Publishing mender-monitor-demo version ${MENDER_MONITOR_VERSION} to s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/${MENDER_MONITOR_VERSION}/"
+    -   aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/${MENDER_MONITOR_VERSION}/
+    - fi
     # Make copies in known destinations to be consumed by get.mender.io script:
     # * For "experimental" channel, we make a copy of the newest master package in the master directory
     # * For "stable" channel, we make a copy in a separate "latest" subdirectory of the latest tagged version
     # This can to be reworked for better maintainability, see MEN-5029 for more details.
     - if is_build_tag ${MENDER_MONITOR_VERSION} || [ "${MENDER_MONITOR_VERSION}" == "master" ]; then
     -   aws s3 cp output/commercial/mender-monitor_*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/master/mender-monitor_master-1_all.deb
-    -   aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/master/mender-monitor-demo_master-1_all.deb
+    -   if test -f output/commercial/mender-monitor-demo*.deb; then
+    -     aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/master/mender-monitor-demo_master-1_all.deb
+    -  fi
     - fi
     - if is_final_tag ${MENDER_MONITOR_VERSION}; then
     -   aws s3 cp output/commercial/mender-monitor_*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/latest/mender-monitor_latest-1_all.deb
-    -   aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/latest/mender-monitor-demo_latest-1_all.deb
+    -   if test -f output/commercial/mender-monitor-demo*.deb; then
+    -     aws s3 cp output/commercial/mender-monitor-demo*.deb s3://${S3_BUCKET_NAME_PRIVATE}/${S3_BUCKET_SUBPATH_MONITOR}/latest/mender-monitor-demo_latest-1_all.deb
+    -   fi
     - fi
 
 publish:s3:mender-monitor:manual:


### PR DESCRIPTION
    pipeline: publish mender-monitor: Add guards around demo package
    
    Which does not exist for 1.0.x builds



    pipeline: publish commercial: comment out the "latest" updates
    
    The logic is not good enough and would have overridden recently released
    mender-monitor 1.1.0 with soon to be released mender-monitor 1.0.1 (both
    are final tags!)
    
    We are following up in MEN-5029.
