### PR TITLE
Fixes to debian.tar.xz files generation.

### DIFF
--- a/docker-build-package
+++ b/docker-build-package
@@ -117,7 +117,7 @@ else
     BUILD_TYPE=any
 fi
 
-if [ "$commercial" != "true" ]; then
+if [ "$commercial" != "true" -a "$ARCH" = "amd64" ]; then
     echo "Including source packages in the build."
     BUILD_TYPE="source,${BUILD_TYPE}"
 fi


### PR DESCRIPTION
This one addresses the problem of checksums mismatch for debian.tar.xz files, which are generated per distribution,
e.g.: `mender-client_3.3.0~git20220215.a905a0a-1+debian+buster+builder474683108.debian.tar.xz`, but contain 
the timestamp of generation and the username and user email in the debian/changelog. It ensures that the debian/changelog will be the same across all the architectures.

The other option is to create source packages per distribution, right now we are building sources for all cases.

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>