### PR TITLE
Revert "install the missing enabled directory"

### DIFF
--- a/scripts/install-mender.sh
+++ b/scripts/install-mender.sh
@@ -355,13 +355,6 @@ EOF
     fi
 }
 
-do_install_missing_monitor_dirs () {
-    if [[ "$SELECTED_COMPONENTS" == *"mender-monitor-demo"* ]]; then
-        mkdir -p /etc/mender-monitor/monitor.d/enabled || true
-        mkdir -p /etc/mender-monitor/monitor.d/available || true
-    fi
-}
-
 command_exists() {
     command -v "$@" > /dev/null 2>&1
 }
@@ -479,6 +472,5 @@ do_install_open
 do_install_commercial
 do_setup_mender_client
 do_setup_other_components
-do_install_missing_monitor_dirs
 
 exit 0

--- a/tests/test_package_addons.py
+++ b/tests/test_package_addons.py
@@ -162,3 +162,7 @@ class TestPackageAddons:
             "test -x /usr/share/mender-monitor/mender-monitord"
         )
         setup_tester_ssh_connection.run("test -x /etc/mender-monitor/monitor.d/log.sh")
+        setup_tester_ssh_connection.run("test -d /etc/mender-monitor/monitor.d/enabled")
+        setup_tester_ssh_connection.run(
+            "test -d /etc/mender-monitor/monitor.d/available"
+        )


### PR DESCRIPTION
This reverts commit 842c78efae610ceff5dac96b198925f5f53485ee.

Signed-off-by: Peter Grzybowski <peter@northern.tech>