### PR TITLE
do not package .git or debian directory, publish same orig file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -400,9 +400,13 @@ test:acceptance:
     - aws s3 mv lock s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/lock
   script:
     # Upload files: first .buildinfo and .deb, then .changes
+    - REFERENCE_ORIG_FILE_PATH=output/opensource/debian-buster-amd64
     - for d in output/opensource/*; do
-    -   find "$d" -name '*.buildinfo' -o -name '*.deb' -o -name '*.orig.tar.*' -o -name '*.debian.tar.*' -o -name '*.dsc' | while read -r file; do
+    -   find "$d" -name '*.buildinfo' -o -name '*.deb' -o -name '*.debian.tar.*' -o -name '*.dsc' | while read -r file; do
     -     aws s3 cp "$file" "s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/${d}/"
+    -   done
+    -   find "$d" -name '*.orig.tar.*' | while read -r file; do
+    -     aws s3 cp "${REFERENCE_ORIG_FILE_PATH}/`basename $file`" "s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/${d}/"
     -   done
     -   find "$d" -name '*.changes' | while read -r file; do
     -     aws s3 cp "$file" "s3://$S3_BUCKET_NAME/$S3_BUCKET_REPO_PATH/${d}/"

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -174,9 +174,11 @@ build_packages() {
   if [[ $DEB_BUILD_TYPE =~ source ]]; then
     # dh_make needs a name of the user in the env
     export USER=root
-    # needed to get the orig file, returns 1 because debian directory exists,
+    # we do not need the .git nor debian directory in the orig file
+    tar --exclude .git --exclude debian -czvf /tmp/"${DEB_PACKAGE}_${DEB_VERSION_NO_REV}".orig.tar.gz .
+    # dh_make returns 1 because debian directory exists,
     # hence the || true, without orig file buildpackage command would fail
-    dh_make --createorig --packagename "${DEB_PACKAGE}_${DEB_VERSION_NO_REV}" -s -y || true
+    dh_make --file /tmp/"${DEB_PACKAGE}_${DEB_VERSION_NO_REV}".orig.tar.gz --packagename "${DEB_PACKAGE}_${DEB_VERSION_NO_REV}" -s -y || true
   fi
 
   case "$ARCH" in


### PR DESCRIPTION
exclude .git and debian directories in orig file, use one orig file.

 * build the orig.tar file by ourselves: excluding .git (not needed) and
   debian (present in debian.tar file) directories
 * tar produces different checksums for identical directories occupying
   different inodes: in the publish stage we copy one and same orig file
   (the contents of it never change between distros, release names, archs)

Ticket: QA-404
Signed-off-by: Peter Grzybowski <peter@northern.tech>