### PR TITLE
ci: install openssh-client instead of openssh

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,7 +382,7 @@ test:acceptance:
     - git submodule sync --recursive
     - git submodule update --init --recursive
   script:
-    - apk --update --no-cache add python3 py3-pip gcc openssh make openssl-dev
+    - apk --update --no-cache add python3 py3-pip gcc openssh-client make openssl-dev
       libffi-dev libc-dev python3-dev bash musl-dev rust cargo
     - cd tests
     - pip3 install -r requirements.txt


### PR DESCRIPTION
Avoid the following error:

ERROR: unable to select packages:
  openssh-client-common-9.0_p1-r1:
    breaks: openssh-client-default-9.0_p1-r2[openssh-client-common=9.0_p1-r2]

Changelog: None
Ticket: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>