### PR TITLE
fix(mender-deb-package): Set mtime before use

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -165,6 +165,8 @@ postprocess_recipe() {
 }
 
 build_orig() {
+  # we need to reset the mtim to some fixed date
+  DEFAULT_MTIME=1621101293
   # we do not need the .git nor debian directory in the orig file
   tar --sort=name --mtime="@${DEFAULT_MTIME}" --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime --exclude .git --exclude debian -czf /tmp/"${DEB_PACKAGE}_${DEB_VERSION_NO_REV}".orig.tar.gz .
 }
@@ -182,8 +184,6 @@ build_packages() {
   if [[ $DEB_BUILD_TYPE =~ source ]]; then
     # dh_make needs a name of the user in the env
     export USER=root
-    # we need to reset the mtim to some fixed date
-    DEFAULT_MTIME=1621101293
     # Copy orig tarball to create the source package
     cp -v /output/*orig.tar.gz /tmp/;
     # dh_make returns 1 because debian directory exists,


### PR DESCRIPTION
Amends commit 2cd7728fc15b9816781d9ac8ac9de0995c72aa9a

This is necessary to produce identical tarballs (same checksums).