### PR TITLE
fix: Different pipelines produce different gzip headers in orig files.

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -168,7 +168,7 @@ build_orig() {
   # we need to reset the mtim to some fixed date
   DEFAULT_MTIME=1621101293
   # we do not need the .git nor debian directory in the orig file
-  tar --sort=name --mtime="@${DEFAULT_MTIME}" --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime --exclude .git --exclude debian -czf /tmp/"${DEB_PACKAGE}_${DEB_VERSION_NO_REV}".orig.tar.gz .
+  GZIP=-n tar --sort=name --mtime="@${DEFAULT_MTIME}" --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime --exclude .git --exclude debian -czf /tmp/"${DEB_PACKAGE}_${DEB_VERSION_NO_REV}".orig.tar.gz .
 }
 
 build_packages() {


### PR DESCRIPTION
Behold: run two pipelines in master and get the different chksums for orig files.
At the same time the orig files in one pipeline is the same (as it should be).

```
#diff mender-client_3.4.0~git20220906.783b4b7.orig.tar.gz.hx re-run/mender-client_3.4.0~git20220906.783b4b7.orig.tar.gz.hx
1c1
< 00000000  1f 8b 08 00 f8 5b 17 63  00 03 ec 5c eb 76 db 46  |.....[.c...\.v.F|
---
> 00000000  1f 8b 08 00 07 63 17 63  00 03 ec 5c eb 76 db 46  |.....c.c...\.v.F|
```

fun facts: gzip header:
```
+0 +1 +2 +3 +4 +5 +6 +7
1f 8b 08 N1 T1 T2 T3 T4
```

`1f 8b` -- magic number
`08` -- deflate
N1 -- flags
T1,T2,T3,T4 -- four bytes of timestamp

Hence proposed fix to include `-n` in gzip flags.

Changelog: Title
Ticket: None
Signed-off-by: Peter Grzybowski <peter@northern.tech>