### PR TITLE
feat: Do not publish more orig files than needed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,7 +248,6 @@ build:packages:debian:buster:armhf:
     RELEASE: "buster"
     ARCH: "armhf"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:debian:buster:armhf
   extends: .template:build:packages
 
@@ -258,7 +257,6 @@ build:packages:debian:buster:arm64:
     RELEASE: "buster"
     ARCH: "arm64"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:debian:buster:arm64
   extends: .template:build:packages
 
@@ -278,7 +276,6 @@ build:packages:debian:bullseye:armhf:
     RELEASE: "bullseye"
     ARCH: "armhf"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:debian:bullseye:armhf
   extends: .template:build:packages
 
@@ -288,7 +285,6 @@ build:packages:debian:bullseye:arm64:
     RELEASE: "bullseye"
     ARCH: "arm64"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:debian:bullseye:arm64
   extends: .template:build:packages
 
@@ -308,7 +304,6 @@ build:packages:ubuntu:bionic:armhf:
     RELEASE: "bionic"
     ARCH: "armhf"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:ubuntu:bionic:armhf
   extends: .template:build:packages
 
@@ -318,7 +313,6 @@ build:packages:ubuntu:bionic:arm64:
     RELEASE: "bionic"
     ARCH: "arm64"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:ubuntu:bionic:arm64
   extends: .template:build:packages
 
@@ -338,7 +332,6 @@ build:packages:ubuntu:focal:armhf:
     RELEASE: "focal"
     ARCH: "armhf"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:ubuntu:focal:armhf
   extends: .template:build:packages
 
@@ -348,7 +341,6 @@ build:packages:ubuntu:focal:arm64:
     RELEASE: "focal"
     ARCH: "arm64"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:ubuntu:focal:arm64
   extends: .template:build:packages
 
@@ -368,7 +360,6 @@ build:packages:ubuntu:jammy:armhf:
     RELEASE: "jammy"
     ARCH: "armhf"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:ubuntu:jammy:armhf
   extends: .template:build:packages
 
@@ -378,7 +369,6 @@ build:packages:ubuntu:jammy:arm64:
     RELEASE: "jammy"
     ARCH: "arm64"
   dependencies:
-    - build:orig:debian:buster:amd64
     - build:image:ubuntu:jammy:arm64
   extends: .template:build:packages
 

--- a/docker-build-package
+++ b/docker-build-package
@@ -116,7 +116,12 @@ elif [ "${SAVE_ORIG}" == "true" ]; then
 fi
 mkdir -p "${output_dir}"
 
-[[ "${SAVE_ORIG}" != "true" ]] && cp -v output/opensource/orig/*orig.tar.* "${output_dir}/"
+# we build source packages only for amd64 and for non-commercial
+# (non source closed) components. there is no need to copy the orig
+# file if we do not need it, since later, during publication to the apt-repo
+# we clean them from incoming based on changes file, which refers to orig files
+# only for source builds. See MEN-5879.
+[[ "${SAVE_ORIG}" != "true" && "$commercial" != "true" && "$ARCH" == "amd64" ]] && mv -v output/opensource/orig/${recipe_name}*orig.tar.* "${output_dir}/"
 
 if [ "$arch_indep" = "true" -a "$ARCH" = "amd64" ]; then
     # On amd64, build architecture independent packages.


### PR DESCRIPTION
The publication of the packages to the apt-repo left some orig files.
It turns out those were unreferenced orig files coming from two sources:

* opensource/orig/ directory: where we store the orig file in ci pipeline
* orig files copied during the binary package build that got propagated
  but never had an entry in the .changes file

We do not need to publish the `orig` directory nor the unreferenced
orig files. This patch takes care of that.

Changelog: Title
Ticket: MEN-5879
Signed-off-by: Peter Grzybowski <peter@northern.tech>