### PR TITLE
ci: Pin the builder image to an specific version

### DIFF
--- a/docker-build-package
+++ b/docker-build-package
@@ -142,7 +142,7 @@ docker run --rm \
         -e MENDER_PRIVATE_REPO_ACCESS_TOKEN="${MENDER_PRIVATE_REPO_ACCESS_TOKEN}" \
         -e MENDER_PRIVATE_REPO_ACCESS_USER="${MENDER_PRIVATE_REPO_ACCESS_USER}" \
         -e MENDER_PRIVATE_GPG_KEY_BUILD="${MENDER_PRIVATE_GPG_KEY_BUILD}" \
-        ${IMAGE_NAME_PREFIX}-${DISTRO}-${RELEASE}-${ARCH}-master \
+        ${IMAGE_NAME_PREFIX}-${DISTRO}-${RELEASE}-${ARCH}-912267927-pin \
         /script \
         ${recipe_name} \
         ${BUILD_TYPE} \


### PR DESCRIPTION
While introducing support for C++ sources we have broken support for golang sources. See MEN-6579.

While we fix the mentioned issue, we can use a fixed version on master to keep the pipelines running.