### PR TITLE
ci: Skip building source packages

### DIFF
--- a/docker-build-package
+++ b/docker-build-package
@@ -129,10 +129,10 @@ else
     BUILD_TYPE=any
 fi
 
-if [ "$commercial" != "true" -a "$ARCH" = "amd64" ]; then
-    echo "Including source packages in the build."
-    BUILD_TYPE="source,${BUILD_TYPE}"
-fi
+# if [ "$commercial" != "true" -a "$ARCH" = "amd64" ]; then
+#     echo "Including source packages in the build."
+#     BUILD_TYPE="source,${BUILD_TYPE}"
+# fi
 echo
 
 docker run --rm \


### PR DESCRIPTION
This will also have to be re-enabled with MEN-6579.