### PR TITLE
ci: Do not pass `MENDER_PRIVATE_REPO_ACCESS_TOKEN` to the container

### DIFF
--- a/docker-build-package
+++ b/docker-build-package
@@ -139,7 +139,6 @@ docker run --rm \
         --volume $(pwd)/${output_dir}:/output \
         --volume $(pwd)/${orig_dir}:/orig \
         --volume $(pwd)/mender-deb-package:/script \
-        -e MENDER_PRIVATE_REPO_ACCESS_TOKEN="${MENDER_PRIVATE_REPO_ACCESS_TOKEN}" \
         -e MENDER_PRIVATE_REPO_ACCESS_USER="${MENDER_PRIVATE_REPO_ACCESS_USER}" \
         -e MENDER_PRIVATE_GPG_KEY_BUILD="${MENDER_PRIVATE_GPG_KEY_BUILD}" \
         ${IMAGE_NAME_PREFIX}-${DISTRO}-${RELEASE}-${ARCH}-912267927-pin \


### PR DESCRIPTION
This is just a clean-up: this variable is not used from inside the container.