### PR TITLE
perf: Switch to shallow git clones

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -55,7 +55,7 @@ checkout_repo_clean_local_path() {
 
 checkout_repo() {
   local -r repo_path=$(checkout_repo_clean_local_path "${REPO_URL}")
-  git clone --recurse-submodules --branch ${VERSION} ${REPO_URL} ${repo_path}
+  git clone --depth 1 --recurse-submodules --branch ${VERSION} ${REPO_URL} ${repo_path}
   cd ${repo_path}
 }
 


### PR DESCRIPTION
Note that the submodules are still doing full clones. Otherwise the cloning fails for some submodules due to objects being "unadvertised".