### PR TITLE
MEN-6858: Update `Depends` for supported `mender-connect` recipes

### DIFF
--- a/recipes/mender-connect/debian-master/control
+++ b/recipes/mender-connect/debian-master/control
@@ -7,9 +7,9 @@ Build-Depends: debhelper (>= 9)
 
 Package: mender-connect
 Architecture: any
-Depends: mender-client (>3.2.0), ${shlibs:Depends}, ${misc:Depends}
-# debian bullseye Depends: mender-client (>= 3.1.99), libc6 (>= 2.3.2), libglib2.0-0 (>= 2.26.0)
-# debian buster Depends: mender-client (>= 3.1.99), libc6 (>= 2.3.2), libglib2.0-0 (>= 2.26.0)
+Depends: mender-client (>3.2.0) | mender-auth, ${shlibs:Depends}, ${misc:Depends}
+# debian bullseye Depends: mender-client (>3.2.0) | mender-auth, libc6 (>= 2.3.2), libglib2.0-0 (>= 2.26.0)
+# debian buster Depends: mender-client (>3.2.0) | mender-auth, libc6 (>= 2.3.2), libglib2.0-0 (>= 2.26.0)
 Description: Mender Connect
  Mender Connect is a Mender add-on which enhances the Mender Client providing a bidirectional
  communication channel with the server. It supports the following troubleshooting features:


### PR DESCRIPTION
It requires either `mender-client` or `mender-auth`, which is one of the new packages being distributed as part of Mender client 4.0 onwards.