### PR TITLE
Misc fixes for building and testing `mender-client` golang and tagged versions

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -231,6 +231,7 @@ EOF
                 --build-indep \
                 --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' \
                 debian/control
+  rm -f ${DEB_PACKAGE}-build-deps-indep_*
 
   # See MEN-6794 for more details.
   # Install also the builder architecture dependencies for dh_shlibdeps to work correctly.
@@ -245,6 +246,7 @@ EOF
                 --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' \
                 --host-arch ${ARCH} \
                 debian/control
+  rm -f ${DEB_PACKAGE}-build-deps-depends_*
 
   case "$ARCH" in
     amd64)

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -151,7 +151,7 @@ prepare_recipe() {
   fi
 
   # For legacy OS, patch the debian/rules file for mender-client
-  if [ "${DEB_PACKAGE}" = "mender-client" ]; then
+  if [[ "${DEB_PACKAGE}" == "mender-client" && -f "debian/rules.legacy.patch" ]]; then
     if [[ "$OS_CODENAME" == "buster" || "$OS_CODENAME" = "focal" ]]; then
       patch debian/rules debian/rules.legacy.patch
     fi

--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -212,7 +212,7 @@ class TestPackageMenderClientDefaults(PackageMenderClientChecker):
 
         # Install the deb package. On failure, install the missing dependencies.
         result = setup_tester_ssh_connection.run(
-            "sudo dpkg --install "
+            "sudo DEBIAN_FRONTEND=noninteractive dpkg --install "
             + package_filename(mender_dist_packages_versions["mender-client"])
             + "|| sudo apt-get -f -y install"
         )


### PR DESCRIPTION
The patch only exists for `mender-client` 4.0 onwards.