### PR TITLE
MEN-6914: Revert "perf: Switch to shallow git clones"

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -55,7 +55,7 @@ checkout_repo_clean_local_path() {
 
 checkout_repo() {
   local -r repo_path=$(checkout_repo_clean_local_path "${REPO_URL}")
-  git clone --depth 1 --recurse-submodules --branch ${VERSION} ${REPO_URL} ${repo_path}
+  git clone --recurse-submodules --branch ${VERSION} ${REPO_URL} ${repo_path}
   cd ${repo_path}
 }
 

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -55,7 +55,7 @@ checkout_repo_clean_local_path() {
 
 checkout_repo() {
   local -r repo_path=$(checkout_repo_clean_local_path "${REPO_URL}")
-  git clone --recurse-submodules --branch ${VERSION} ${REPO_URL} ${repo_path}
+  git clone --recurse-submodules --branch "${VERSION}" "${REPO_URL}" "${repo_path}"
   cd ${repo_path}
 }
 


### PR DESCRIPTION
Unfortunately we rely on all tags being fetched, so we cannot use shallow clones. Use a shallow clone + `git fetch --tags` is the same as doing a full clone in the first place.

Ticket: MEN-6914

This reverts commit 73ab939e77b8aeeb948a3ed70d96d9fb5aa6cef9.