### PR TITLE
MEN-6915: Remove debug symbols packages for the C++ recipes

### DIFF
--- a/recipes/mender-client/debian-master/rules
+++ b/recipes/mender-client/debian-master/rules
@@ -33,3 +33,8 @@ override_dh_auto_install:
 	for file in debian/tmp/etc/mender/inventory/*; do \
 		ln -sf /etc/mender/inventory/"$$(basename "$$file")" debian/tmp/usr/share/mender/inventory/; \
 	done
+
+# Do not build debug symbols packages
+# See https://northerntech.atlassian.net/browse/MEN-6915
+override_dh_strip:
+	dh_strip --no-automatic-dbgsym

--- a/recipes/mender-flash/debian-master/rules
+++ b/recipes/mender-flash/debian-master/rules
@@ -10,3 +10,8 @@ override_dh_auto_configure:
 
 override_dh_auto_test:
 	true
+
+# Do not build debug symbols packages
+# See https://northerntech.atlassian.net/browse/MEN-6915
+override_dh_strip:
+	dh_strip --no-automatic-dbgsym


### PR DESCRIPTION
This was added unintentionally and is causing trouble for Ubuntu distributions in our APT repositories. See JIRA ticket for more details.