### PR TITLE
fix: `mender-flash` should not depend on anything

### DIFF
--- a/recipes/mender-flash/debian-master/control
+++ b/recipes/mender-flash/debian-master/control
@@ -9,6 +9,6 @@ Homepage: https://mender.io
 
 Package: mender-flash
 Architecture: any
-Depends: mender-update, ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Mender Flash is an utility to flash block devices used by the Mender Client
  to write into the inactive partition during a rootfs update.

--- a/recipes/mender-flash/debian-master/control
+++ b/recipes/mender-flash/debian-master/control
@@ -4,7 +4,6 @@ Section: admin
 Priority: optional
 Standards-Version: 4.0.0
 Build-Depends-Indep: cmake, debhelper (>= 10)
-# Build-Depends: debhelper-compat (= 13)
 Build-Depends: libstdc++-dev
 Homepage: https://mender.io
 


### PR DESCRIPTION
It is an standalone tool.