### PR TITLE
MEN-6939: Update script for the new packages

### DIFF
--- a/scripts/install-mender.sh
+++ b/scripts/install-mender.sh
@@ -106,7 +106,7 @@ usage() {
     echo ""
     echo "If no components are specified, defaults will be installed"
     echo ""
-    echo "Anything after a '--' gets passed directly to 'mender setup' command."
+    echo "Anything after a '--' gets passed directly to 'mender-setup' command."
     echo ""
     echo "Supported components (x = installed by default):"
     for c in $AVAILABLE_COMPONENTS; do
@@ -376,7 +376,7 @@ do_install_open() {
        -o Dpkg::Options::="--force-confold" \
        $selected_components_open
 
-    echo "  Success! Please run \`mender setup\` to configure the client."
+    echo "  Success! Please run \`mender-setup\` to configure the client."
 }
 
 do_install_commercial() {
@@ -436,9 +436,10 @@ do_setup_mender_client() {
         return
     fi
 
-    echo "  Setting up mender with options: $MENDER_SETUP_ARGS"
-    mender setup $MENDER_SETUP_ARGS
-    pidof systemd && systemctl restart mender-client
+    echo "  Setting up mender-setup with options: $MENDER_SETUP_ARGS"
+    mender-setup $MENDER_SETUP_ARGS
+    pidof systemd && systemctl restart mender-authd
+    pidof systemd && systemctl restart mender-updated
     echo "  Success!"
 }
 

--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -127,8 +127,9 @@ class TestInstallMenderScript:
     ):
         """Pass mender setup args, should be propagated"""
 
+        # MEN-6947: Using experimental until mender-setup 1.0.0 is released
         generic_debian_container.run(
-            f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s -- -- --demo --device-type cool-device --hosted-mender --tenant-token my-secret-token"
+            f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s -- -c experimental -- --demo --device-type cool-device --hosted-mender --tenant-token my-secret-token"
         )
 
         result = generic_debian_container.run("cat /etc/mender/mender.conf")

--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -136,7 +136,7 @@ class TestInstallMenderScript:
         assert '"ServerURL": "https://hosted.mender.io"' in result.stdout.decode()
 
         result = generic_debian_container.run("cat /var/lib/mender/device_type")
-        assert result.stdout.decode() == "device_type=cool-device"
+        assert result.stdout.decode().strip() == "device_type=cool-device"
 
         result = generic_debian_container.run("cat /etc/mender/mender-connect.conf")
         assert '"User": "nobody"' in result.stdout.decode()


### PR DESCRIPTION
Related to the C++ update, where `mender-setup` is its own standalone tool and systemd services have been split.