### PR TITLE
Misc fixes for `mender-client` packages

### DIFF
--- a/recipes/mender-client/debian-master/mender-auth.install
+++ b/recipes/mender-client/debian-master/mender-auth.install
@@ -1,3 +1,4 @@
+/etc/mender/identity/*
 /lib/systemd/system/mender-authd.service
 /usr/bin/mender-auth
 /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf

--- a/recipes/mender-client/debian-master/mender-auth.install
+++ b/recipes/mender-client/debian-master/mender-auth.install
@@ -1,4 +1,5 @@
 /lib/systemd/system/mender-authd.service
 /usr/bin/mender-auth
-/usr/share/mender/identity
+/usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf
 /usr/share/doc/mender-auth/examples/demo.crt
+/usr/share/mender/identity

--- a/recipes/mender-client/debian-master/mender-auth.install
+++ b/recipes/mender-client/debian-master/mender-auth.install
@@ -1,4 +1,4 @@
 /lib/systemd/system/mender-authd.service
 /usr/bin/mender-auth
 /usr/share/mender/identity
-/usr/share/doc/mender/examples/demo.crt
+/usr/share/doc/mender-auth/examples/demo.crt

--- a/recipes/mender-client/debian-master/mender-update.install
+++ b/recipes/mender-client/debian-master/mender-update.install
@@ -4,4 +4,3 @@
 /usr/share/mender/inventory/*
 /etc/mender/scripts/version
 /etc/mender/inventory/*
-/etc/mender/identity/*

--- a/tests/test_package_client_cpp.py
+++ b/tests/test_package_client_cpp.py
@@ -116,7 +116,7 @@ all_files = [
     #
     # Demo certificate
     #
-    {"name": "/usr/share/doc/mender/examples/demo.crt", "type": "file",},
+    {"name": "/usr/share/doc/mender-auth/examples/demo.crt", "type": "file",},
     #
     # Device type file
     # Installed by mender-setup

--- a/tests/test_package_client_cpp.py
+++ b/tests/test_package_client_cpp.py
@@ -114,6 +114,13 @@ all_files = [
     {"name": "/lib/systemd/system/mender-updated.service", "type": "file",},
     {"name": "/lib/systemd/system/mender-authd.service", "type": "file",},
     #
+    # D-Bus policy files
+    #
+    {
+        "name": "/usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf",
+        "type": "file",
+    },
+    #
     # Demo certificate
     #
     {"name": "/usr/share/doc/mender-auth/examples/demo.crt", "type": "file",},


### PR DESCRIPTION
* MEN-6941: Correct path for the demo certificate
* MEN-6942: Add missing D-Bus policy file
* Move identity scripts to the right package