### PR TITLE
MEN-6945: Handle diversion of files when upgrading to `mender-client` 4.0

### DIFF
--- a/recipes/mender-client/debian-master/mender-auth.postrm
+++ b/recipes/mender-client/debian-master/mender-auth.postrm
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+ACTION="$1"
+OLD_VERSION="$2"
+NEW_VERSION="$3"
+
+case "$ACTION" in
+    abort-install)
+        dpkg-divert --remove --no-rename /usr/share/mender/identity/mender-device-identity
+        dpkg-divert --remove --no-rename /etc/mender/identity/mender-device-identity
+        dpkg-divert --remove --no-rename /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf
+        ;;
+
+    *)
+        # Nothing to do for upgrades.
+        ;;
+esac
+
+exit 0

--- a/recipes/mender-client/debian-master/mender-auth.preinst
+++ b/recipes/mender-client/debian-master/mender-auth.preinst
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+ACTION="$1"
+OLD_VERSION="$2"
+NEW_VERSION="$3"
+
+case "$ACTION" in
+    install)
+        # mender-auth is going to replace files that are owned by the old
+        # mender-client. mender-client is also going to be installed, which will remove
+        # those files and solve those conflicts, but not until later. Therefore we need to
+        # divert these files now, and restore them after the new mender-client package is
+        # also installed.
+        dpkg-divert --add --no-rename /usr/share/mender/identity/mender-device-identity
+        dpkg-divert --add --no-rename /etc/mender/identity/mender-device-identity
+        dpkg-divert --add --no-rename /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf
+        ;;
+
+    *)
+        # Nothing to do for upgrades.
+        ;;
+esac
+
+exit 0

--- a/recipes/mender-client/debian-master/mender-update.postrm
+++ b/recipes/mender-client/debian-master/mender-update.postrm
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e
+
+ACTION="$1"
+OLD_VERSION="$2"
+NEW_VERSION="$3"
+
+case "$ACTION" in
+    abort-install)
+        dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-bootloader-integration
+        dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-hostinfo
+        dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-network
+        dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-os
+        dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-provides
+        dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-rootfs-type
+        dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-update-modules
+        dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/deb
+        dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/directory
+        dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/docker
+        dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/rootfs-image
+        dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/rpm
+        dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/script
+        dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/single-file
+        dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-bootloader-integration
+        dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-hostinfo
+        dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-network
+        dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-os
+        dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-provides
+        dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-rootfs-type
+        dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-update-modules
+        dpkg-divert --remove --no-rename /etc/mender/scripts/version
+        ;;
+
+    *)
+        # Nothing to do for upgrades.
+        ;;
+esac
+
+exit 0

--- a/recipes/mender-client/debian-master/mender-update.preinst
+++ b/recipes/mender-client/debian-master/mender-update.preinst
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -e
+
+ACTION="$1"
+OLD_VERSION="$2"
+NEW_VERSION="$3"
+
+case "$ACTION" in
+    install)
+        # mender-update is going to replace files that are owned by the old
+        # mender-client. mender-client is also going to be installed, which will remove
+        # those files and solve those conflicts, but not until later. Therefore we need to
+        # divert these files now, and restore them after the new mender-client package is
+        # also installed.
+        dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-bootloader-integration
+        dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-hostinfo
+        dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-network
+        dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-os
+        dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-provides
+        dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-rootfs-type
+        dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-update-modules
+        dpkg-divert --add --no-rename /usr/share/mender/modules/v3/deb
+        dpkg-divert --add --no-rename /usr/share/mender/modules/v3/directory
+        dpkg-divert --add --no-rename /usr/share/mender/modules/v3/docker
+        dpkg-divert --add --no-rename /usr/share/mender/modules/v3/rootfs-image
+        dpkg-divert --add --no-rename /usr/share/mender/modules/v3/rpm
+        dpkg-divert --add --no-rename /usr/share/mender/modules/v3/script
+        dpkg-divert --add --no-rename /usr/share/mender/modules/v3/single-file
+        dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-bootloader-integration
+        dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-hostinfo
+        dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-network
+        dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-os
+        dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-provides
+        dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-rootfs-type
+        dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-update-modules
+        dpkg-divert --add --no-rename /etc/mender/scripts/version
+        ;;
+
+    *)
+        # Nothing to do for upgrades.
+        ;;
+esac
+
+exit 0

--- a/recipes/mender-client/debian-master/postinst
+++ b/recipes/mender-client/debian-master/postinst
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+ACTION="$1"
+
+case "$ACTION" in
+    # We always want to do this.
+    *)
+        # Restore files that were diverted during an upgrade from mender-client < 4.0 to mender-auth
+        # and mender-upgrade. Use `--quiet` to avoid a lot of messages in case the files are not
+        # diverted, which will usually be the case.
+        dpkg-divert --package mender-auth --quiet --remove --rename /usr/share/mender/identity/mender-device-identity
+        dpkg-divert --package mender-auth --quiet --remove --rename /etc/mender/identity/mender-device-identity
+        dpkg-divert --package mender-auth --quiet --remove --rename /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf
+        dpkg-divert --package mender-update --quiet --remove --rename /etc/mender/inventory/mender-inventory-bootloader-integration
+        dpkg-divert --package mender-update --quiet --remove --rename /etc/mender/inventory/mender-inventory-hostinfo
+        dpkg-divert --package mender-update --quiet --remove --rename /etc/mender/inventory/mender-inventory-network
+        dpkg-divert --package mender-update --quiet --remove --rename /etc/mender/inventory/mender-inventory-os
+        dpkg-divert --package mender-update --quiet --remove --rename /etc/mender/inventory/mender-inventory-provides
+        dpkg-divert --package mender-update --quiet --remove --rename /etc/mender/inventory/mender-inventory-rootfs-type
+        dpkg-divert --package mender-update --quiet --remove --rename /etc/mender/inventory/mender-inventory-update-modules
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/modules/v3/deb
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/modules/v3/directory
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/modules/v3/docker
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/modules/v3/rootfs-image
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/modules/v3/rpm
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/modules/v3/script
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/modules/v3/single-file
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-bootloader-integration
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-hostinfo
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-network
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-os
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-provides
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-rootfs-type
+        dpkg-divert --package mender-update --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-update-modules
+        dpkg-divert --package mender-update --quiet --remove --rename /etc/mender/scripts/version
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
Based on the research from Kristian Amlie. See:
* https://github.com/kacf/mender-dist-packages/commit/0dac3e66097aa54fdb071ea3492a14c8840654dc

With the new packaging, the files that used to belong to `mender-client` are now owned by `mender-auth` and `mender-update`.

Add `preinst` scripts to the new packages to divert the files and a `postinst` to `mender-client` to restore the diversions. See inline comments for more context.

Added a test to verify the upgrade path.