### PR TITLE
MEN-6965: Support downgrade of `mender-client` from 4 to v3

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -87,16 +87,26 @@ get_deb_distribution() {
   fi
 }
 
+# This function declares three variables for the rest of the script to use:
+#   DEB_VERSION          The full Debian technical version
+#   DEB_VERSION_NO_REV   The Git version of the package, either tag or X.Y.Z~gitDATE
+#   DEB_VERSION_NO_EPOCH The Debian version minus the epoch, matching the string in the filename
 get_deb_version() {
   # Create a version from Git.
-  #  - For Git tags: X.Y.Z-<debian_suffix>
-  #  - For master: X.Y.Z~git<commit-date>.<commit-sha>-<debian_suffix>+b<BUILD_ID>
+  #  - For Git tags: <debian-epoch>X.Y.Z-<debian_suffix>
+  #  - For master: <debian-epoch>X.Y.Z~git<commit-date>.<commit-sha>-<debian_suffix>+b<BUILD_ID>
   #     where X.Y.Z is latest tag (not necessarily matching git describe)
+  debian_epoch=""
+  if [ "${DEB_PACKAGE}" = "mender-client" ]; then
+    debian_epoch="1:"
+  fi
   debian_suffix="1+$OS_DISTRO+$OS_CODENAME"
   if [ "$VERSION" != "master" ] && git describe --tags --exact-match 2>/dev/null; then
     DEB_VERSION="$(git describe --tags --exact-match)"
     DEB_VERSION_NO_REV="${DEB_VERSION}"
     DEB_VERSION="${DEB_VERSION}-${debian_suffix}"
+    DEB_VERSION_NO_EPOCH="${DEB_VERSION}"
+    DEB_VERSION="${debian_epoch}${DEB_VERSION}"
   else
     DEB_VERSION="$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -rV | head -n1)"
     if [ -z "${DEB_VERSION}" ]; then
@@ -115,6 +125,8 @@ get_deb_version() {
     # this has to have something to do with the `b` being a prefix
     # to binary numbers in perl
     DEB_VERSION="${DEB_VERSION}+builder${BUILD_ID}"
+    DEB_VERSION_NO_EPOCH="${DEB_VERSION}"
+    DEB_VERSION="${debian_epoch}${DEB_VERSION}"
   fi
 }
 
@@ -345,7 +357,7 @@ copy_deb_packages() {
     cp ${file} /output
   done
   # Echo the package version to /output
-  echo ${DEB_VERSION} > /output/${DEB_PACKAGE}-deb-version
+  echo ${DEB_VERSION_NO_EPOCH} > /output/${DEB_PACKAGE}-deb-version
   # Give packages same owner as the folder.
   chown --reference /output /output/*
 }

--- a/recipes/mender-client/debian-3.5.x/control
+++ b/recipes/mender-client/debian-3.5.x/control
@@ -6,7 +6,9 @@ Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9)
 
 Package: mender-client
-Conflicts: mender
+Conflicts: mender, mender-auth, mender-update, mender-snapshot, mender-setup
+Replaces: mender-auth, mender-update, mender-snapshot, mender-setup
+Provides: mender-auth, mender-update, mender-snapshot, mender-setup
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 # debian bullseye Depends: libc6 (>= 2.14), libglib2.0-0 (>= 2.26.0), liblzma5 (>= 5.1.1alpha+20120614), libssl1.1 (>= 1.1.1)

--- a/recipes/mender-client/debian-3.5.x/postinst
+++ b/recipes/mender-client/debian-3.5.x/postinst
@@ -2,6 +2,8 @@
 
 set -e
 
+ACTION="$1"
+
 # If the file exists, we understand that mender setup was already run or
 # the device was manually configured at some point. Do nothing.
 if [ ! -f /etc/mender/mender.conf ]; then
@@ -26,5 +28,38 @@ if [ ! -f /etc/mender/mender.conf ]; then
     fi
 
 fi
+
+case "$ACTION" in
+    # We always want to do this.
+    *)
+        # Restore files that were diverted during an downgrade from mender-client v4. Use `--quiet`
+        # to avoid a lot of messages in case the files are not diverted, which will usually be the case.
+        dpkg-divert --quiet --remove --rename /usr/share/mender/identity/mender-device-identity
+        dpkg-divert --quiet --remove --rename /etc/mender/identity/mender-device-identity
+        dpkg-divert --quiet --remove --rename /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf
+        dpkg-divert --quiet --remove --rename /etc/mender/inventory/mender-inventory-bootloader-integration
+        dpkg-divert --quiet --remove --rename /etc/mender/inventory/mender-inventory-hostinfo
+        dpkg-divert --quiet --remove --rename /etc/mender/inventory/mender-inventory-network
+        dpkg-divert --quiet --remove --rename /etc/mender/inventory/mender-inventory-os
+        dpkg-divert --quiet --remove --rename /etc/mender/inventory/mender-inventory-provides
+        dpkg-divert --quiet --remove --rename /etc/mender/inventory/mender-inventory-rootfs-type
+        dpkg-divert --quiet --remove --rename /etc/mender/inventory/mender-inventory-update-modules
+        dpkg-divert --quiet --remove --rename /usr/share/mender/modules/v3/deb
+        dpkg-divert --quiet --remove --rename /usr/share/mender/modules/v3/directory
+        dpkg-divert --quiet --remove --rename /usr/share/mender/modules/v3/docker
+        dpkg-divert --quiet --remove --rename /usr/share/mender/modules/v3/rootfs-image
+        dpkg-divert --quiet --remove --rename /usr/share/mender/modules/v3/rpm
+        dpkg-divert --quiet --remove --rename /usr/share/mender/modules/v3/script
+        dpkg-divert --quiet --remove --rename /usr/share/mender/modules/v3/single-file
+        dpkg-divert --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-bootloader-integration
+        dpkg-divert --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-hostinfo
+        dpkg-divert --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-network
+        dpkg-divert --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-os
+        dpkg-divert --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-provides
+        dpkg-divert --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-rootfs-type
+        dpkg-divert --quiet --remove --rename /usr/share/mender/inventory/mender-inventory-update-modules
+        dpkg-divert --quiet --remove --rename /etc/mender/scripts/version
+        ;;
+esac
 
 #DEBHELPER#

--- a/recipes/mender-client/debian-3.5.x/postrm
+++ b/recipes/mender-client/debian-3.5.x/postrm
@@ -2,9 +2,63 @@
 
 set -e
 
-if [ "$1" == "purge" ]; then
-    rm -f /etc/mender/mender.conf
-    rm -f /var/lib/mender/device_type
-fi
+ACTION="$1"
+OLD_VERSION="$2"
+NEW_VERSION="$3"
+
+case "$ACTION" in
+    purge)
+        rm -f /etc/mender/mender.conf
+        rm -f /var/lib/mender/device_type
+        ;;
+    abort-upgrade)
+        case "$OLD_VERSION" in
+            4.*)
+                # Aborting the upgrade from v4 we need to give back ownership of the conffiles
+                # to mender-auth and mender-update packages and restore the systemd services
+                # mender-auth files
+                dpkg-divert --remove --no-rename /usr/share/mender/identity/mender-device-identity
+                dpkg-divert --remove --no-rename /etc/mender/identity/mender-device-identity
+                dpkg-divert --remove --no-rename /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf
+                # mender-update files
+                dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-bootloader-integration
+                dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-hostinfo
+                dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-network
+                dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-os
+                dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-provides
+                dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-rootfs-type
+                dpkg-divert --remove --no-rename /etc/mender/inventory/mender-inventory-update-modules
+                dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/deb
+                dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/directory
+                dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/docker
+                dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/rootfs-image
+                dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/rpm
+                dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/script
+                dpkg-divert --remove --no-rename /usr/share/mender/modules/v3/single-file
+                dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-bootloader-integration
+                dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-hostinfo
+                dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-network
+                dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-os
+                dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-provides
+                dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-rootfs-type
+                dpkg-divert --remove --no-rename /usr/share/mender/inventory/mender-inventory-update-modules
+                dpkg-divert --remove --no-rename /etc/mender/scripts/version
+                # restore the v4 services
+                systemctl enable mender-authd
+                systemctl start mender-authd
+                systemctl enable mender-updated
+                systemctl start mender-updated
+                ;;
+
+            *)
+                # Nothing to do for v3 or older.
+                ;;
+        esac
+        ;;
+
+    *)
+        # Nothing to do for new installs.
+        ;;
+esac
 
 #DEBHELPER#

--- a/recipes/mender-client/debian-3.5.x/preinst
+++ b/recipes/mender-client/debian-3.5.x/preinst
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+
+ACTION="$1"
+OLD_VERSION="$2"
+NEW_VERSION="$3"
+
+case "$ACTION" in
+    upgrade)
+        case "$OLD_VERSION" in
+            4.*)
+                # Downgrading from v4 we need to take back ownership of the conffiles that were
+                # split into mender-auth and mender-update packages and disable the systemd services
+                # mender-auth files
+                dpkg-divert --add --no-rename /usr/share/mender/identity/mender-device-identity
+                dpkg-divert --add --no-rename /etc/mender/identity/mender-device-identity
+                dpkg-divert --add --no-rename /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf
+                # mender-update files
+                dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-bootloader-integration
+                dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-hostinfo
+                dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-network
+                dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-os
+                dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-provides
+                dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-rootfs-type
+                dpkg-divert --add --no-rename /etc/mender/inventory/mender-inventory-update-modules
+                dpkg-divert --add --no-rename /usr/share/mender/modules/v3/deb
+                dpkg-divert --add --no-rename /usr/share/mender/modules/v3/directory
+                dpkg-divert --add --no-rename /usr/share/mender/modules/v3/docker
+                dpkg-divert --add --no-rename /usr/share/mender/modules/v3/rootfs-image
+                dpkg-divert --add --no-rename /usr/share/mender/modules/v3/rpm
+                dpkg-divert --add --no-rename /usr/share/mender/modules/v3/script
+                dpkg-divert --add --no-rename /usr/share/mender/modules/v3/single-file
+                dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-bootloader-integration
+                dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-hostinfo
+                dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-network
+                dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-os
+                dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-provides
+                dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-rootfs-type
+                dpkg-divert --add --no-rename /usr/share/mender/inventory/mender-inventory-update-modules
+                dpkg-divert --add --no-rename /etc/mender/scripts/version
+                # stop and disable the v4 services
+                if systemctl is-active mender-authd; then
+                    systemctl stop mender-authd
+                    systemctl disable mender-authd
+                fi
+                if systemctl is-active mender-updated; then
+                    systemctl stop mender-updated
+                    systemctl disable mender-updated
+                fi
+                ;;
+
+            *)
+                # Nothing to do for v3 or older.
+                ;;
+        esac
+        ;;
+
+    *)
+        # Nothing to do for install.
+        ;;
+esac
+
+exit 0

--- a/recipes/mender-client/debian-master/mender-auth.postrm
+++ b/recipes/mender-client/debian-master/mender-auth.postrm
@@ -18,4 +18,4 @@ case "$ACTION" in
         ;;
 esac
 
-exit 0
+#DEBHELPER#

--- a/recipes/mender-client/debian-master/mender-update.postrm
+++ b/recipes/mender-client/debian-master/mender-update.postrm
@@ -37,4 +37,4 @@ case "$ACTION" in
         ;;
 esac
 
-exit 0
+#DEBHELPER#

--- a/recipes/mender-client/debian-master/postinst
+++ b/recipes/mender-client/debian-master/postinst
@@ -38,4 +38,4 @@ case "$ACTION" in
         ;;
 esac
 
-exit 0
+#DEBHELPER#

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,6 +15,8 @@
 
 import os.path
 
+from fabric import Result as FabricResult
+
 tests_path = os.path.dirname(os.path.realpath(__file__))
 output_path = os.path.normpath(os.path.join(tests_path, "..", "output"))
 
@@ -58,3 +60,14 @@ def upload_deb_package(
     ssh_connection.put(
         package_filename_path(package_version, package_name, package_arch)
     )
+
+
+def check_installed(conn, pkg, installed=True):
+    """Check whether the given package is installed on the device given by
+    conn."""
+
+    res = conn.run(f"dpkg --status {pkg}", warn=True)
+    if isinstance(res, FabricResult):
+        assert (res.return_code == 0) == installed
+    else:
+        assert (res.returncode == 0) == installed

--- a/tests/test_dist_packages_versions.py
+++ b/tests/test_dist_packages_versions.py
@@ -15,8 +15,6 @@
 
 import re
 
-import pytest
-
 
 def verify_package_version(version, deb_version):
     # For master, expect something like: "0.0~git20191022.dade697-1+debian+buster+b279517265"

--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -21,8 +21,7 @@ import subprocess
 import threading
 
 import pytest
-from fabric import Result as FabricResult
-from helpers import packages_path
+from helpers import packages_path, check_installed
 
 SCRIPT_SERVER_ADDR = "localhost"
 SCRIPT_SERVER_PORT = 8000
@@ -125,17 +124,6 @@ def local_apt_repo_from_upstream_packages(container, pool_paths, dest):
         container.run(f"cd {dest} && curl --remote-name {url}")
 
     prepare_local_apt_repo(container, dest)
-
-
-def check_installed(conn, pkg, installed=True):
-    """Check whether the given package is installed on the device given by
-    conn."""
-
-    res = conn.run(f"dpkg --status {pkg}", warn=True)
-    if isinstance(res, FabricResult):
-        assert (res.return_code == 0) == installed
-    else:
-        assert (res.returncode == 0) == installed
 
 
 @pytest.mark.usefixtures("script_server")

--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -91,24 +91,40 @@ def generic_debian_container(request):
     return c
 
 
-def put_all_packages(container, dest):
+def put_all_built_packages(container, dest):
     container.run(f"mkdir -p {dest}")
     for package in glob.glob(packages_path("mender-client", "amd64") + "/*.deb"):
         container.put(package, dest)
 
 
-def prepare_local_apt_repo(container):
-    # Copy freshly built packages and configure a local APT repo with dpkg-dev. See:
+def prepare_local_apt_repo(container, packages_path):
+    # Configure a local APT repo with dpkg-dev. See:
     # https://askubuntu.com/questions/458748/is-it-possible-to-add-a-location-folder-on-my-hard-disk-to-sources-list
-    put_all_packages(container, "/packages")
     container.run("apt install -y dpkg-dev")
     container.run(
-        "cd /packages && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz"
+        f"cd {packages_path} && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz"
+    )
+    sources_list_file = (
+        f"/etc/apt/sources.list.d/{os.path.basename(packages_path)}.list"
     )
     container.run(
-        "echo deb [trusted=yes] file:/packages ./ > /etc/apt/sources.list.d/packages.list"
+        f"echo deb [trusted=yes] file:{packages_path} ./ > {sources_list_file}"
     )
     container.run("apt update")
+
+
+def local_apt_repo_from_built_packages(container):
+    put_all_built_packages(container, "/packages")
+    prepare_local_apt_repo(container, "/packages")
+
+
+def local_apt_repo_from_upstream_packages(container, pool_paths, dest):
+    container.run(f"mkdir {dest}")
+    for path in pool_paths:
+        url = f"https://downloads.mender.io/repos/debian/pool/main/{path}"
+        container.run(f"cd {dest} && curl --remote-name {url}")
+
+    prepare_local_apt_repo(container, dest)
 
 
 def check_installed(conn, pkg, installed=True):
@@ -231,7 +247,7 @@ class TestInstallMenderScript:
         )
 
         # And now upgrade to the freshly built packages
-        prepare_local_apt_repo(generic_debian_container)
+        local_apt_repo_from_built_packages(generic_debian_container)
         generic_debian_container.run("apt -y upgrade")
 
         # All packages should be upgraded
@@ -241,6 +257,124 @@ class TestInstallMenderScript:
         check_installed(generic_debian_container, "mender-flash")
         check_installed(generic_debian_container, "mender-setup")
         check_installed(generic_debian_container, "mender-snapshot")
+        check_installed(generic_debian_container, "mender-connect")
+        check_installed(generic_debian_container, "mender-configure")
+
+
+@pytest.mark.usefixtures("script_server")
+class TestUpgradeMenderV4:
+    def test_upgrade_from_v3_to_v4_to_build(
+        self, generic_debian_container,
+    ):
+        # Install mender-client 3.5.2
+        local_apt_repo_from_upstream_packages(
+            generic_debian_container,
+            [
+                "m/mender-client/mender-client_3.5.2-1+debian+buster_amd64.deb",
+                "m/mender-connect/mender-connect_2.2.0-1+debian+buster_amd64.deb",
+                "m/mender-configure/mender-configure_1.1.1-1+debian+buster_all.deb",
+            ],
+            "/mender_3_5_2",
+        )
+        generic_debian_container.run(
+            "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-client mender-connect mender-configure"
+        )
+
+        check_installed(generic_debian_container, "mender-client")
+        check_installed(generic_debian_container, "mender-connect")
+        check_installed(generic_debian_container, "mender-configure")
+
+        # Upgrade to mender-client 4.0.0
+        local_apt_repo_from_upstream_packages(
+            generic_debian_container,
+            [
+                "m/mender-client/mender-client_4.0.0-1+debian+buster_amd64.deb",
+                "m/mender-client/mender-update_4.0.0-1+debian+buster_amd64.deb",
+                "m/mender-client/mender-auth_4.0.0-1+debian+buster_amd64.deb",
+                "m/mender-flash/mender-flash_1.0.0-1+debian+buster_amd64.deb",
+                "m/mender-setup/mender-setup_1.0.0-1+debian+buster_amd64.deb",
+                "m/mender-snapshot/mender-snapshot_1.0.0-1+debian+buster_amd64.deb",
+                "m/mender-connect/mender-connect_2.2.0-1+debian+buster_amd64.deb",
+                "m/mender-configure/mender-configure_1.1.2-1+debian+buster_all.deb",
+            ],
+            "/mender_4_0_0",
+        )
+        # Note the use of apt instead of apt-get - the latter wouldn't install the new packages
+        generic_debian_container.run("apt --assume-yes upgrade")
+        check_installed(generic_debian_container, "mender-client")
+        check_installed(generic_debian_container, "mender-update")
+        check_installed(generic_debian_container, "mender-auth")
+        check_installed(generic_debian_container, "mender-flash")
+        check_installed(generic_debian_container, "mender-setup")
+        check_installed(generic_debian_container, "mender-snapshot")
+        check_installed(generic_debian_container, "mender-connect")
+        check_installed(generic_debian_container, "mender-configure")
+
+        # Upgrade to the freshly built packages
+        local_apt_repo_from_built_packages(generic_debian_container)
+        generic_debian_container.run("apt --assume-yes upgrade")
+        check_installed(generic_debian_container, "mender-client")
+        check_installed(generic_debian_container, "mender-update")
+        check_installed(generic_debian_container, "mender-auth")
+        check_installed(generic_debian_container, "mender-flash")
+        check_installed(generic_debian_container, "mender-setup")
+        check_installed(generic_debian_container, "mender-snapshot")
+        check_installed(generic_debian_container, "mender-connect")
+        check_installed(generic_debian_container, "mender-configure")
+
+    def test_upgrade_from_v3_to_build(
+        self, generic_debian_container,
+    ):
+        # Install mender-client 3.5.2
+        local_apt_repo_from_upstream_packages(
+            generic_debian_container,
+            [
+                "m/mender-client/mender-client_3.5.2-1+debian+buster_amd64.deb",
+                "m/mender-connect/mender-connect_2.2.0-1+debian+buster_amd64.deb",
+                "m/mender-configure/mender-configure_1.1.1-1+debian+buster_all.deb",
+            ],
+            "/mender_3_5_2",
+        )
+        generic_debian_container.run(
+            "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-client mender-connect mender-configure"
+        )
+        check_installed(generic_debian_container, "mender-client")
+        check_installed(generic_debian_container, "mender-connect")
+        check_installed(generic_debian_container, "mender-configure")
+
+        # Upgrade to the freshly built packages
+        local_apt_repo_from_built_packages(generic_debian_container)
+        generic_debian_container.run("apt --assume-yes upgrade")
+        check_installed(generic_debian_container, "mender-client")
+        check_installed(generic_debian_container, "mender-connect")
+        check_installed(generic_debian_container, "mender-configure")
+
+    def test_upgrade_from_v4_to_build(
+        self, generic_debian_container,
+    ):
+        # Install mender-client 4.0.0
+        local_apt_repo_from_upstream_packages(
+            generic_debian_container,
+            [
+                "m/mender-client/mender-client_4.0.0-1+debian+buster_amd64.deb",
+                "m/mender-client/mender-update_4.0.0-1+debian+buster_amd64.deb",
+                "m/mender-client/mender-auth_4.0.0-1+debian+buster_amd64.deb",
+                "m/mender-flash/mender-flash_1.0.0-1+debian+buster_amd64.deb",
+                "m/mender-setup/mender-setup_1.0.0-1+debian+buster_amd64.deb",
+                "m/mender-snapshot/mender-snapshot_1.0.0-1+debian+buster_amd64.deb",
+                "m/mender-connect/mender-connect_2.2.0-1+debian+buster_amd64.deb",
+                "m/mender-configure/mender-configure_1.1.2-1+debian+buster_all.deb",
+            ],
+            "/mender_4_0_0",
+        )
+        generic_debian_container.run(
+            "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-client mender-connect mender-configure"
+        )
+
+        # Upgrade to the freshly built packages
+        local_apt_repo_from_built_packages(generic_debian_container)
+        generic_debian_container.run("apt --assume-yes upgrade")
+        check_installed(generic_debian_container, "mender-client")
         check_installed(generic_debian_container, "mender-connect")
         check_installed(generic_debian_container, "mender-configure")
 

--- a/tests/test_package_addons.py
+++ b/tests/test_package_addons.py
@@ -14,10 +14,9 @@
 #    limitations under the License.
 
 import pytest
-import os.path
 import re
 
-from helpers import package_filename, upload_deb_package
+from helpers import package_filename, upload_deb_package, check_installed
 
 
 @pytest.mark.usefixtures("setup_mender_configured")
@@ -36,24 +35,13 @@ class TestPackageAddons:
         )
 
         # Install
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --install "
             + package_filename(
                 mender_dist_packages_versions["mender-connect"], "mender-connect"
             )
         )
-        assert (
-            "Unpacking mender-connect ("
-            + mender_dist_packages_versions["mender-connect"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-connect ("
-            + mender_dist_packages_versions["mender-connect"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-connect")
 
         # Check mender-connect files
         setup_tester_ssh_connection.run("test -x /usr/bin/mender-connect")
@@ -87,7 +75,7 @@ class TestPackageAddons:
         )
 
         # Install
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --install "
             + package_filename(
                 mender_dist_packages_versions["mender-configure"],
@@ -95,18 +83,7 @@ class TestPackageAddons:
                 "all",
             )
         )
-        assert (
-            "Unpacking mender-configure ("
-            + mender_dist_packages_versions["mender-configure"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-configure ("
-            + mender_dist_packages_versions["mender-configure"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-configure")
 
         # Check mender-configure files
         setup_tester_ssh_connection.run(
@@ -136,7 +113,7 @@ class TestPackageAddons:
         assert result.exited == 0
 
         # Install
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --install "
             + package_filename(
                 mender_dist_packages_versions["mender-monitor"],
@@ -144,18 +121,7 @@ class TestPackageAddons:
                 "all",
             )
         )
-        assert (
-            "Unpacking mender-monitor ("
-            + mender_dist_packages_versions["mender-monitor"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-monitor ("
-            + mender_dist_packages_versions["mender-monitor"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-monitor")
 
         # Check mender-monitor files
         setup_tester_ssh_connection.run(

--- a/tests/test_package_app_update_module.py
+++ b/tests/test_package_app_update_module.py
@@ -16,7 +16,7 @@
 import pytest
 import os.path
 
-from helpers import package_filename, upload_deb_package
+from helpers import package_filename, upload_deb_package, check_installed
 from mender_test_containers.helpers import *
 
 
@@ -60,7 +60,7 @@ class TestPackageMenderAppUpdateModule(PackageMenderAppUpdateModuleChecker):
             package_arch="all",
         )
 
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --ignore-depends=mender-client --install "
             + package_filename(
                 mender_dist_packages_versions["mender-app-update-module"],
@@ -68,18 +68,7 @@ class TestPackageMenderAppUpdateModule(PackageMenderAppUpdateModuleChecker):
                 package_arch="all",
             ),
         )
-        assert (
-            "Unpacking mender-app-update-module ("
-            + mender_dist_packages_versions["mender-app-update-module"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-app-update-module ("
-            + mender_dist_packages_versions["mender-app-update-module"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-app-update-module")
 
         self.check_installed_files(setup_tester_ssh_connection)
 

--- a/tests/test_package_client_dev.py
+++ b/tests/test_package_client_dev.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from helpers import package_filename, upload_deb_package
+from helpers import package_filename, upload_deb_package, check_installed
 
 
 @pytest.mark.usefixtures("setup_mender_configured")
@@ -33,7 +33,7 @@ class TestPackageDev:
         )
 
         # Install
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --ignore-depends=mender-client --install "
             + package_filename(
                 mender_dist_packages_versions["mender-client"],
@@ -41,18 +41,7 @@ class TestPackageDev:
                 package_arch="all",
             )
         )
-        assert (
-            "Unpacking mender-client-dev ("
-            + mender_dist_packages_versions["mender-client"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-client-dev ("
-            + mender_dist_packages_versions["mender-client"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-client-dev")
 
         # Check mender-client-dev files
         setup_tester_ssh_connection.run(

--- a/tests/test_package_flash.py
+++ b/tests/test_package_flash.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from helpers import package_filename, upload_deb_package
+from helpers import package_filename, upload_deb_package, check_installed
 from mender_test_containers.helpers import *
 
 
@@ -34,24 +34,13 @@ class TestPackageFlash:
             package_name="mender-flash",
         )
 
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --install --ignore-depends=mender-update "
             + package_filename(
                 mender_dist_packages_versions["mender-flash"],
                 package_name="mender-flash",
             ),
         )
-        assert (
-            "Unpacking mender-flash ("
-            + mender_dist_packages_versions["mender-flash"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-flash ("
-            + mender_dist_packages_versions["mender-flash"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-flash")
 
         setup_tester_ssh_connection.run("test -x /usr/bin/mender-flash")

--- a/tests/test_package_gateway.py
+++ b/tests/test_package_gateway.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from helpers import package_filename, upload_deb_package
+from helpers import package_filename, upload_deb_package, check_installed
 
 
 class TestPackageGateway:
@@ -31,24 +31,13 @@ class TestPackageGateway:
         )
 
         # Install
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --install "
             + package_filename(
                 mender_dist_packages_versions["mender-gateway"], "mender-gateway",
             )
         )
-        assert (
-            "Unpacking mender-gateway ("
-            + mender_dist_packages_versions["mender-gateway"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-gateway ("
-            + mender_dist_packages_versions["mender-gateway"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-gateway")
 
         # Check mender-gateway files
         setup_tester_ssh_connection.run("test -x /usr/bin/mender-gateway")

--- a/tests/test_package_setup.py
+++ b/tests/test_package_setup.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from helpers import package_filename, upload_deb_package
+from helpers import package_filename, upload_deb_package, check_installed
 from mender_test_containers.helpers import *
 
 
@@ -34,25 +34,14 @@ class TestPackageSetup:
             package_name="mender-setup",
         )
 
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo DEBIAN_FRONTEND=noninteractive dpkg --install "
             + package_filename(
                 mender_dist_packages_versions["mender-setup"],
                 package_name="mender-setup",
             ),
         )
-        assert (
-            "Unpacking mender-setup ("
-            + mender_dist_packages_versions["mender-setup"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-setup ("
-            + mender_dist_packages_versions["mender-setup"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-setup")
         setup_tester_ssh_connection.run("test -x /usr/bin/mender-setup")
         setup_tester_ssh_connection.run("test -f /etc/mender/mender.conf")
         setup_tester_ssh_connection.run("test -f /var/lib/mender/device_type")

--- a/tests/test_package_snapshot.py
+++ b/tests/test_package_snapshot.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from helpers import package_filename, upload_deb_package
+from helpers import package_filename, upload_deb_package, check_installed
 from mender_test_containers.helpers import *
 
 
@@ -34,24 +34,13 @@ class TestPackageSnapshot:
             package_name="mender-snapshot",
         )
 
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --install "
             + package_filename(
                 mender_dist_packages_versions["mender-snapshot"],
                 package_name="mender-snapshot",
             ),
         )
-        assert (
-            "Unpacking mender-snapshot ("
-            + mender_dist_packages_versions["mender-snapshot"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-snapshot ("
-            + mender_dist_packages_versions["mender-snapshot"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-snapshot")
 
         setup_tester_ssh_connection.run("test -x /usr/bin/mender-snapshot")

--- a/tests/test_package_tools.py
+++ b/tests/test_package_tools.py
@@ -13,9 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import pytest
-
-from helpers import package_filename, upload_deb_package
+from helpers import package_filename, upload_deb_package, check_installed
 
 
 class TestPackageArtifact:
@@ -30,24 +28,13 @@ class TestPackageArtifact:
         )
 
         # Install
-        result = setup_tester_ssh_connection.run(
+        setup_tester_ssh_connection.run(
             "sudo dpkg --install "
             + package_filename(
                 mender_dist_packages_versions["mender-artifact"], "mender-artifact",
             )
         )
-        assert (
-            "Unpacking mender-artifact ("
-            + mender_dist_packages_versions["mender-artifact"]
-            + ")"
-            in result.stdout
-        )
-        assert (
-            "Setting up mender-artifact ("
-            + mender_dist_packages_versions["mender-artifact"]
-            + ")"
-            in result.stdout
-        )
+        check_installed(setup_tester_ssh_connection, "mender-artifact")
 
         # Check mender-artifact files
         setup_tester_ssh_connection.run("test -x /usr/bin/mender-artifact")


### PR DESCRIPTION
* fix: Add placeholders for debhelper for `mender-client` master
    
    These are needed in order to the systemd services to be started and
    stopped automatically by `apt-get install` or `remove`.


* fix: Support downgrade of `mender-client` from 4 to v3
    
    This commit consist on various parts:
    * Introduce an epoch for all `mender-client` package builds so that we
      can publish a `1:3.5.2` that will be upgradable from already
      published `4.0.0` version. See:
      https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
    * Add `preinst` and `postrm` scripts on the 3.5.x series to detect
      an "upgrade" from v4 and:
        * Take back ownership of the configuration files
        * Disable `mender-authd` and `mender-updated` systemd services as
          this was missing from the first publishing of the packages (see
          previous commit)
    * Mark the `mender-client` 3.5.x series package as conflict, replaces
      and provides of the new packages, so that they get removed when
      installing `mender-client`. See:
      https://www.debian.org/doc/debian-policy/ch-relationships.html#replacing-whole-packages-forcing-their-removal
    * New tests for the different upgrade paths. Note that these make only
      sense when building a 3.5.2 or newer 3.5.x *tag*.
