### PR TITLE
Add libsystemd-dev as a build dependency for mender-client.

### DIFF
--- a/recipes/mender-client/debian-master/control
+++ b/recipes/mender-client/debian-master/control
@@ -4,7 +4,7 @@ Section: admin
 Priority: optional
 Standards-Version: 4.0.0
 Build-Depends-Indep: cmake, debhelper (>= 10)
-Build-Depends: liblmdb-dev (>= 0.9.7), libc6-dev (>= 2.14), libboost-dev (>= 1.67.0), libboost-filesystem-dev (>= 1.67.0), libboost-log-dev (>= 1.67.0), libboost-regex-dev (>= 1.67.0), libboost-chrono-dev (>= 1.67.0), libboost-thread-dev (>= 1.67.0), libboost-atomic-dev (>= 1.67.0),  libssl-dev (>= 1.1.1), libarchive-dev (>= 3.2.2), libdbus-1-dev
+Build-Depends: liblmdb-dev (>= 0.9.7), libc6-dev (>= 2.14), libboost-dev (>= 1.67.0), libboost-filesystem-dev (>= 1.67.0), libboost-log-dev (>= 1.67.0), libboost-regex-dev (>= 1.67.0), libboost-chrono-dev (>= 1.67.0), libboost-thread-dev (>= 1.67.0), libboost-atomic-dev (>= 1.67.0),  libssl-dev (>= 1.1.1), libarchive-dev (>= 3.2.2), libdbus-1-dev, libsystemd-dev
 Homepage: https://mender.io
 
 Package: mender-client


### PR DESCRIPTION
Honestly I think this is a mistake by the upstream maintainers. Preumably it's because systemd is now providing dbus services, but this should not affect which package you need to depend on, at least not in a stable release.