### PR TITLE
MEN-7010: Fix `Depends` metadata for the Mender addons

### DIFF
--- a/recipes/mender-app-update-module/debian-master/control
+++ b/recipes/mender-app-update-module/debian-master/control
@@ -7,8 +7,7 @@ Build-Depends: debhelper (>= 9)
 
 Package: mender-app-update-module
 Architecture: all
-Depends: mender-client (>3.2.0), ${misc:Depends}
+Depends: mender-update | mender-client (>3.2.0), ${misc:Depends}
 Description: Mender Application Update Modules
  Mender provides application updates via modules. They provide
  a way to update and manage container-based deployments.
- 

--- a/recipes/mender-configure/debian-master/control
+++ b/recipes/mender-configure/debian-master/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9)
 
 Package: mender-configure
 Architecture: all
-Depends: dbus, curl, mender-client (>=2.5.0), ${misc:Depends}
+Depends: dbus, curl, mender-update | mender-client (>=2.5.0), ${misc:Depends}
 Description: Mender Configure
  Mender Configure is a Mender add-on which enhances the Mender Client providing an Update
  Module to configure the device

--- a/recipes/mender-connect/debian-master/control
+++ b/recipes/mender-connect/debian-master/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9)
 
 Package: mender-connect
 Architecture: any
-Depends: mender-client (>3.2.0) | mender-auth, ${shlibs:Depends}, ${misc:Depends}
+Depends: mender-auth | mender-client (>3.2.0), ${shlibs:Depends}, ${misc:Depends}
 # debian bullseye Depends: mender-client (>3.2.0) | mender-auth, libc6 (>= 2.3.2), libglib2.0-0 (>= 2.26.0)
 # debian buster Depends: mender-client (>3.2.0) | mender-auth, libc6 (>= 2.3.2), libglib2.0-0 (>= 2.26.0)
 Description: Mender Connect

--- a/recipes/mender-monitor/debian-master/control
+++ b/recipes/mender-monitor/debian-master/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9)
 
 Package: mender-monitor
 Architecture: all
-Depends: bash, lmdb-utils, mender-client (>=2.5.0), ${misc:Depends}
+Depends: bash, lmdb-utils, mender-auth | mender-client (>=2.5.0), ${misc:Depends}
 Description: Mender Monitor client
  Mender Monitor is a Mender add-on which enables the reporting of certain
  device events to the Mender server, such as log events, service files statuses


### PR DESCRIPTION
Besides `mender-client`, they need to accept also either `mender-auth` or `mender-update` as a replacement.

Note that `mender-connect` was correct, we are only re-ordering it for consistency with the rest.