### PR TITLE
MEN-7010: Support for overriding the Debian suffix in the package version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,12 @@ variables:
   FF_NETWORK_PER_BUILD: 1
   # Builder image version
   IMAGE_VERSION: "master"
+  # Debian suffix
+  OVERRIDE_DEBIAN_SUFFIX:
+    value: ""
+    description: |-
+      Overrides Debian suffix, which by default is "-1". Use it to manually build (and publish)
+      a new version of a package from already released (git tagged) software.
 
 # NOTE: To add distributions, modify first the matrix in mender-test-containers repository
 .mender-dist-packages-image-matrix:

--- a/docker-build-package
+++ b/docker-build-package
@@ -170,8 +170,8 @@ docker run --rm \
         --volume $(pwd)/${output_dir}:/output \
         --volume $(pwd)/${orig_dir}:/orig \
         --volume $(pwd)/mender-deb-package:/script \
-        -e MENDER_PRIVATE_REPO_ACCESS_USER="${MENDER_PRIVATE_REPO_ACCESS_USER}" \
-        -e MENDER_PRIVATE_GPG_KEY_BUILD="${MENDER_PRIVATE_GPG_KEY_BUILD}" \
+        --env MENDER_PRIVATE_REPO_ACCESS_USER \
+        --env MENDER_PRIVATE_GPG_KEY_BUILD \
         ${IMAGE_NAME_PREFIX}-${DISTRO}-${RELEASE}-${ARCH}-${IMAGE_VERSION:-master} \
         /script \
         ${recipe_name} \

--- a/docker-build-package
+++ b/docker-build-package
@@ -172,6 +172,7 @@ docker run --rm \
         --volume $(pwd)/mender-deb-package:/script \
         --env MENDER_PRIVATE_REPO_ACCESS_USER \
         --env MENDER_PRIVATE_GPG_KEY_BUILD \
+        --env OVERRIDE_DEBIAN_SUFFIX \
         ${IMAGE_NAME_PREFIX}-${DISTRO}-${RELEASE}-${ARCH}-${IMAGE_VERSION:-master} \
         /script \
         ${recipe_name} \

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -100,7 +100,11 @@ get_deb_version() {
   if [ "${DEB_PACKAGE}" = "mender-client" ]; then
     debian_epoch="1:"
   fi
-  debian_suffix="1+$OS_DISTRO+$OS_CODENAME"
+  debian_suffix="1"
+  if [ -n "${OVERRIDE_DEBIAN_SUFFIX}" ]; then
+    debian_suffix="${OVERRIDE_DEBIAN_SUFFIX}"
+  fi
+  debian_suffix="$debian_suffix+$OS_DISTRO+$OS_CODENAME"
   if [ "$VERSION" != "master" ] && git describe --tags --exact-match 2>/dev/null; then
     DEB_VERSION="$(git describe --tags --exact-match)"
     DEB_VERSION_NO_REV="${DEB_VERSION}"

--- a/tests/test_dist_packages_versions.py
+++ b/tests/test_dist_packages_versions.py
@@ -17,16 +17,16 @@ import re
 
 
 def verify_package_version(version, deb_version):
-    # For master, expect something like: "0.0~git20191022.dade697-1+debian+buster+b279517265"
-    master_version_re = re.compile(
-        r"[0-9]+\.[0-9]+\.[0-9]+~git[0-9]+\.([a-z0-9]+)-1\+debian\+buster\+builder([0-9]+|LOCAL)"
-    )
-
     if version == "master":
-        m = master_version_re.match(deb_version)
+        # For master, expect something like: "0.0~git20191022.dade697-1+debian+buster+b279517265"
+        m = re.match(
+            r"[0-9]+\.[0-9]+\.[0-9]+~git[0-9]+\.([a-z0-9]+)-[1-9][0-9]*\+debian\+buster\+builder([0-9]+|LOCAL)",
+            deb_version,
+        )
         assert m is not None, "Cannot match %s" % deb_version
     else:
-        assert deb_version == version + "-1+debian+buster"
+        m = re.match(fr"{version}-[1-9][0-9]*\+debian\+buster", deb_version)
+        assert m is not None, "Cannot match %s" % deb_version
 
 
 def test_versions(

--- a/tests/test_package_addons.py
+++ b/tests/test_package_addons.py
@@ -50,19 +50,6 @@ class TestPackageAddons:
             "test -f /lib/systemd/system/mender-connect.service"
         )
 
-        # Check mender-configure version
-        if mender_connect_version == "master":
-            # For master it will print the short git hash. We can obtain this from the deb
-            # package version, which is something like: "0.0~git20191022.dade697-1"
-            m = re.match(
-                r"[0-9]+\.[0-9]+\.[0-9]+~git[0-9]+\.([a-z0-9]+)-1",
-                mender_dist_packages_versions["mender-connect"],
-            )
-            assert m is not None
-        else:
-            result = setup_tester_ssh_connection.run("mender-connect version")
-            assert mender_connect_version in result.stdout
-
     def test_mender_configure(
         self, setup_tester_ssh_connection, mender_dist_packages_versions
     ):


### PR DESCRIPTION
So that we can publish new packages of already released software.