### PR TITLE
feat: add support for mender-client4, mender-auth and mender-update components

### DIFF
--- a/scripts/install-mender.sh
+++ b/scripts/install-mender.sh
@@ -71,6 +71,12 @@ mender-monitor-demo \
 SELECTED_COMPONENTS="$DEFAULT_COMPONENTS"
 DEMO="0"
 
+if [[ "$*" == *"--force-mender-client4"* ]]; then
+    FORCE_MENDER_CLIENT4="1"
+else
+    FORCE_MENDER_CLIENT4="0"
+fi
+
 # mender-setup CLI
 MENDER_SETUP_CLI="mender-setup"
 
@@ -111,15 +117,22 @@ usage() {
     echo "usage: install-mender.sh [options] [component...] [-- [options-for-mender-setup] ]"
     echo ""
     echo "options: [-h, help] [-c channel] [--demo] [--commercial]"
-    echo "  -h, --help          print this help"
-    echo "  -c CHANNEL          channel: stable(default)|experimental"
-    echo "  --demo              use defaults appropriate for demo"
-    echo "  --commercial        install commercial components, requires --jwt-token"
-    echo "  --jwt-token TOKEN   Hosted Mender JWT token"
+    echo "  -h, --help             print this help"
+    echo "  -c CHANNEL             channel: stable(default)|experimental"
+    echo "  --demo                 use defaults appropriate for demo"
+    echo "  --commercial           install commercial components, requires --jwt-token"
+    echo "  --force-mender-client4 install the Mender Client 4.x series on all the distros"
+    echo "  --jwt-token TOKEN      Hosted Mender JWT token"
     echo ""
     echo "If no components are specified, defaults will be installed"
     echo ""
     echo "Anything after a '--' gets passed directly to '${MENDER_SETUP_CLI}' command."
+    echo ""
+    echo "This script will install the Mender Client 3.x series on Ubuntu jammy or older, "
+    echo "and on Debian bullseye or older. On newer distributions, it will install the "
+    echo "Mender Client 4.x series. If you want to force the installation of the latest "
+    echo "major version of the Mender Client on older distributions, please use the "
+    echo "flag --force-mender-client4."
     echo ""
     echo "Supported components (x = installed by default):"
     for c in $AVAILABLE_COMPONENTS; do
@@ -193,6 +206,8 @@ parse_args() {
                     echo "Aborting."
                     exit 1
                 fi
+                ;;
+            --force-mender-client4)
                 ;;
             --)
                 shift
@@ -499,9 +514,11 @@ command_exists() {
 }
 
 select_mender_client_legacy() {
-    DEFAULT_COMPONENTS="$DEFAULT_COMPONENTS_LEGACY"
-    SELECTED_COMPONENTS="$DEFAULT_COMPONENTS"
-    MENDER_SETUP_CLI="mender setup"
+    if [ "$FORCE_MENDER_CLIENT4" -ne 1 ]; then
+        DEFAULT_COMPONENTS="$DEFAULT_COMPONENTS_LEGACY"
+        SELECTED_COMPONENTS="$DEFAULT_COMPONENTS"
+        MENDER_SETUP_CLI="mender setup"
+    fi
 }
 
 # Set the LSB_DIST and DIST_VERSION variables guessing the distribution and version;

--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Copyright 2021 Northern.tech AS
+# Copyright 2024 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -219,7 +219,7 @@ class TestInstallMenderScript:
             f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s -- mender-connect"
         )
 
-        check_installed(generic_debian_container, "mender-client")
+        check_installed(generic_debian_container, "mender-auth")
         check_installed(generic_debian_container, "mender-connect")
         check_installed(generic_debian_container, "mender-configure", installed=False)
 
@@ -230,7 +230,8 @@ class TestInstallMenderScript:
             f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s -- mender-configure"
         )
 
-        check_installed(generic_debian_container, "mender-client")
+        check_installed(generic_debian_container, "mender-auth")
+        check_installed(generic_debian_container, "mender-update")
         check_installed(generic_debian_container, "mender-connect", installed=False)
         check_installed(generic_debian_container, "mender-configure")
 


### PR DESCRIPTION
From now on, mender-client4 will be a default component in place of mender-client; however, the script falls back to mender-client (legacy, go client) for Ubuntu jammy and focal and for Debian bullseye and buster. As we don't support just yet other distributions, it means that the only way to install the Mender Client version 4 is to specify its components explicitly from the command line. In the future, when we'll support other distributions (e.g., bookworm), mender-client4 will be the default.