### PR TITLE
test: Clean-ups after publishing the new packages

### DIFF
--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -262,20 +262,13 @@ class TestInstallMenderScript:
     def test_upgrade_mender_v4_series_meta_package_with_addons(
         self, generic_debian_container,
     ):
-        # Install latest stable software (client v3)
+        # Install default stable software (legacy client v3 + addons)
         generic_debian_container.run(
             f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s"
         )
 
-        local_apt_repo_from_built_packages(generic_debian_container)
-
-        # MEN-7010
-        # Currently, production mender-configure still depends (only) on mender-client.
-        # We need first to update this one to the freshly built in order to make the rest of the
-        # test succeed. This part can be removed after MEN-7010 is finished.
-        generic_debian_container.run("apt install --assume-yes mender-configure")
-
         # Now install freshly built mender-client4
+        local_apt_repo_from_built_packages(generic_debian_container)
         generic_debian_container.run(
             "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-update mender-client4"
         )
@@ -295,7 +288,7 @@ class TestInstallMenderScript:
     def test_upgrade_mender_v4_series_meta_package_only_client(
         self, generic_debian_container,
     ):
-        # Install latest stable software (client v3)
+        # Install only the legacy client v3)
         generic_debian_container.run(
             f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s -- mender-client"
         )
@@ -318,20 +311,13 @@ class TestInstallMenderScript:
     def test_upgrade_mender_v4_series_explicit_auth_update(
         self, generic_debian_container,
     ):
-        # Install latest stable software (client v3)
+        # Install default stable software (legacy client v3 + addons)
         generic_debian_container.run(
             f"curl http://{SCRIPT_SERVER_ADDR}:{SCRIPT_SERVER_PORT}/install-mender.sh | bash -s"
         )
 
-        local_apt_repo_from_built_packages(generic_debian_container)
-
-        # MEN-7010
-        # Currently, production mender-configure still depends (only) on mender-client.
-        # We need first to update this one to the freshly built in order to make the rest of the
-        # test succeed. This part can be removed after MEN-7010 is finished.
-        generic_debian_container.run("apt install --assume-yes mender-configure")
-
         # Now install freshly built packages
+        local_apt_repo_from_built_packages(generic_debian_container)
         generic_debian_container.run(
             "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-auth mender-update"
         )

--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -270,7 +270,7 @@ class TestInstallMenderScript:
         # Now install freshly built mender-client4
         local_apt_repo_from_built_packages(generic_debian_container)
         generic_debian_container.run(
-            "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-update mender-client4"
+            "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-client4"
         )
 
         # mender-client should be removed and mender-client4 + all packages should be installed


### PR DESCRIPTION
* test: Remove temporary middle step for `mender-configure`
    The new package with the correct dependencies is already in production.

* test: Remove explicit install of `mender-update`
    With the new production packages, this is not required anymore.