### PR TITLE
revert: "test: Remove explicit install of `mender-update`"

### DIFF
--- a/tests/test_install_mender_sh.py
+++ b/tests/test_install_mender_sh.py
@@ -270,7 +270,7 @@ class TestInstallMenderScript:
         # Now install freshly built mender-client4
         local_apt_repo_from_built_packages(generic_debian_container)
         generic_debian_container.run(
-            "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-client4"
+            "DEBIAN_FRONTEND=noninteractive apt install --assume-yes mender-update mender-client4"
         )
 
         # mender-client should be removed and mender-client4 + all packages should be installed


### PR DESCRIPTION
This reverts commit d3f5a5991391fff1f067ad2c4cc1d72229eb2110.

We cannot remove the explicit install of `mender-update` because the test will fail with as follows if the add-on packages (e.g., `mender-connect`) are not upgraded at the same time when upgrading from `mender-client` to `mender-client4`:

```
The following packages have unmet dependencies:
 mender-client4 : Conflicts: mender-client but 1:3.5.2-1+debian+buster is to be installed
E: Unable to correct problems, you have held broken packages.
```

This happens on release pipelines, where we build `mender-connect` and `mender-configure` using an old tag, therefore not triggering an upgrade at the same time we install `mender-client4` to upgrade the Mender client.