### PR TITLE
MEN-7048: Missing `Depends` field for `mender-client4` armhf

### DIFF
--- a/recipes/mender-client4/debian-master/control
+++ b/recipes/mender-client4/debian-master/control
@@ -12,6 +12,7 @@ Conflicts: mender, mender-client
 Replaces: mender-client, mender-auth, mender-update, mender-snapshot, mender-setup
 Architecture: any
 Depends: mender-auth, mender-update, mender-snapshot, mender-setup, mender-flash
+# debian buster Depends: mender-auth, mender-update, mender-snapshot, mender-setup, mender-flash
 Description: Mender client
  Mender is an open source over-the-air (OTA) software updater for embedded Linux devices.
 

--- a/tests/test_package_client_cpp.py
+++ b/tests/test_package_client_cpp.py
@@ -223,7 +223,7 @@ class TestPackageMenderClientDefaults(PackageMenderClientChecker):
 
         # Install the client meta-package also
         setup_tester_ssh_connection.run(
-            "sudo apt install --yes ./"
+            "sudo dpkg --install --ignore-depends=mender-snapshot,mender-setup,mender-flash ./"
             + package_filename(
                 mender_dist_packages_versions["mender-client4"],
                 package_name="mender-client4",


### PR DESCRIPTION
When cross-compiling on armhf, we use a _hack_ to set the dependencies. If in use, it needs to be set for every package in the `control` file.

The test was passing by mistake.