### PR TITLE
fix: makes sure mender setup can run with right permissions

### DIFF
--- a/scripts/install-mender.sh
+++ b/scripts/install-mender.sh
@@ -404,7 +404,7 @@ do_install_open() {
        -o Dpkg::Options::="--force-confold" \
        $selected_components_open
 
-    echo "  Success! Please run \``mender_setup_cli`\` to configure the client."
+    echo "  Success! Please run \``mender_setup_cli`\` as superuser to configure the client."
 }
 
 do_install_commercial() {


### PR DESCRIPTION
To avoid errors like:

$ mender setup
ERRO[0000] Error loading configuration from file: /etc/mender/mender.conf (open /etc/mender/mender.conf: permission denied) ERRO[0000] open /etc/mender/mender.conf: permission denied

Ticket: None
Changelog: None