### PR TITLE
fix: Add `tzdata` dependency to `mender-configure-timezone`

### DIFF
--- a/recipes/mender-configure/debian-master/control
+++ b/recipes/mender-configure/debian-master/control
@@ -14,7 +14,7 @@ Description: Mender Configure
 
 Package: mender-configure-timezone
 Architecture: all
-Depends: mender-configure (= ${binary:Version}), jq, ${misc:Depends}
+Depends: mender-configure (= ${binary:Version}), jq, tzdata, ${misc:Depends}
 Description: Mender Configure Timezone
  Mender Configure Timezone is an add-on to Mender Configure which enables configuration
  of timezone on the device


### PR DESCRIPTION
Otherwise if the package is missing the install fails with:

```
...
Setting up mender-configure-demo (1.1.2-2+ubuntu+jammy) ...
cat: /etc/timezone: No such file or directory
dpkg: error processing package mender-configure-demo (--configure):
 installed mender-configure-demo package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 mender-configure-demo
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

It does not happen in real life because this package is installed by default in Debian/Ubuntu. But it fails on a vanilla Ubuntu Docker image, for example.