### PR TITLE
Move publish:s3 job to hetzner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -311,6 +311,8 @@ test:acceptance:script:
 .template:publish:s3:apt-repo:
   stage: publish
   image: debian:12
+  tags:
+    - hetzner-amd-beefy
   before_script:
     - apt update && apt install -yyq awscli
     # Lock the bucket to block concurrent jobs


### PR DESCRIPTION
Out of public runners, also for performance reasons because the job is painfully slow.

Ticket: SEC-1133