### PR TITLE
perf: speed up aws cli by ignoring imds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,8 @@ variables:
     description: |-
       Overrides Debian suffix, which by default is "-1". Use it to manually build (and publish)
       a new version of a package from already released (git tagged) software.
+  # Don't slow down aws cli commands with connections to IMDS: we're not in AWS
+  AWS_EC2_METADATA_DISABLED: "true"
 
 # NOTE: To add distributions, modify first the matrix in mender-test-containers repository
 .mender-dist-packages-image-matrix:


### PR DESCRIPTION
IMDS is an api service available within AWS. AWS cli by default is trying to get metadata informations from the address 169.254.169.254, which is the internal IMDS endpoint. Our pipelines run in Hetzner and GCP, where this service is not available, and every aws cli command time out for about 5, slowing down the pipelines in the long run.

Ticket: QA-751