### PR TITLE
ci: Fix rules to actually run tests for `mender` 5.x

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -297,7 +297,7 @@ test:acceptance:cpp:
   rules:
     - if: $CI_COMMIT_BRANCH == "production"
       when: never
-    - if: '$TEST_MENDER_DIST_PACKAGES == "true" && $MENDER_VERSION =~ /^4\.[0-9x]\.[0-9x]/'
+    - if: '$TEST_MENDER_DIST_PACKAGES == "true" && $MENDER_VERSION =~ /^[456789]\.[0-9x]\.[0-9x]/'
     - if: '$TEST_MENDER_DIST_PACKAGES == "true" && $MENDER_VERSION == "master"'
   extends: .test:acceptance
   variables:


### PR DESCRIPTION
Make sure the rules match all (or many) of the future major releases.