### PR TITLE
ci: docker login retry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ variables:
 
 .dind-login: &dind-login
   - mkdir -p $HOME/.docker && echo $DOCKER_AUTH_CONFIG > $HOME/.docker/config.json
-  - docker login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
+  - for retry in 1 2 3 4 5; do docker login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY && break || sleep $retry; done
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'


### PR DESCRIPTION
From time to time gitlab.com is timing out when issuing docker login, this change allow for a retry

This should solve this case: https://gitlab.com/Northern.tech/Mender/mender-dist-packages/-/jobs/9126549483

Ticket: QA-921