### PR TITLE
MEN-8141: Update go version to 1.22

### DIFF
--- a/mender-deb-package
+++ b/mender-deb-package
@@ -60,7 +60,7 @@ checkout_repo() {
 }
 
 install_go() {
-  local GOLANG_VERSION=1.21.1
+  local GOLANG_VERSION=1.22.12
   local GOLANG_ARCH=amd64
   local golang_version_set
   if [ $ARCH = "armhf" -a $OS_DISTRO = "raspbian" ]; then


### PR DESCRIPTION
To align with new `mender-artifact` requirements.