### PR TITLE
fix: mender-client4 package should require same version of auth and update

### DIFF
--- a/recipes/mender-client4/debian-4.0.x/control
+++ b/recipes/mender-client4/debian-4.0.x/control
@@ -11,7 +11,7 @@ Package: mender-client4
 Conflicts: mender, mender-client
 Replaces: mender-client, mender-auth, mender-update, mender-snapshot, mender-setup
 Architecture: any
-Depends: mender-auth, mender-update, mender-snapshot, mender-setup, mender-flash
+Depends: mender-auth (= ${source:Version}), mender-update (= ${source:Version}), mender-snapshot, mender-setup, mender-flash
 Description: Mender client
  Mender is an open source over-the-air (OTA) software updater for embedded Linux devices.
 

--- a/recipes/mender-client4/debian-master/control
+++ b/recipes/mender-client4/debian-master/control
@@ -11,7 +11,7 @@ Package: mender-client4
 Conflicts: mender, mender-client
 Replaces: mender-client, mender-auth, mender-update, mender-snapshot, mender-setup
 Architecture: any
-Depends: mender-auth, mender-update, mender-snapshot, mender-setup, mender-flash
+Depends: mender-auth (= ${source:Version}), mender-update (= ${source:Version}), mender-snapshot, mender-setup, mender-flash
 Description: Mender client
  Mender is an open source over-the-air (OTA) software updater for embedded Linux devices.
 


### PR DESCRIPTION
Otherwise installation of `mender-client4` pulls in the lastest available versions of `mender-auth` and `mender-update`, no matter what the version of `mender-client4` is. We need all of them to be in sync.

Ticket: MEN-8476
Changelog: none