### PR TITLE
ci: Test packages in an ARM64 Debian 11 container

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -392,14 +392,23 @@ test:acceptance:golang:
     PYTEST_FILTER: "not cppclient"
 
 test:acceptance:cpp:
+  extends: .test:acceptance
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/debian:bullseye
+  tags:
+    - hetzner-arm
   rules:
     - if: $CI_COMMIT_BRANCH == "production"
       when: never
     - if: '$TEST_MENDER_DIST_PACKAGES == "true" && $MENDER_VERSION =~ /^[456789]\.[0-9x]\.[0-9x]/'
     - if: '$TEST_MENDER_DIST_PACKAGES == "true" && $MENDER_VERSION == "master"'
-  extends: .test:acceptance
   variables:
     PYTEST_FILTER: "not golangclient"
+  before_script:
+    - apt-get update
+    - apt-get -yyq install bash git python3-pip wget sudo
+    - git submodule sync --recursive
+    - git submodule update --init --recursive
+    - pip3 install -r tests/requirements.txt
 
 test:acceptance:script:
   rules:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ import pytest
 from mender_test_containers.container_props import *
 from mender_test_containers.conftest import *
 
-TEST_CONTAINER_LIST = [MenderTestRaspbian]
+TEST_CONTAINER_LIST = [MenderTestNoContainer]
 
 
 @pytest.fixture(scope="session", params=TEST_CONTAINER_LIST)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,7 +28,7 @@ COMMERCIAL_PACKAGES = [
 
 
 # Returns path were to find the package to install
-def packages_path(package, package_arch="armhf"):
+def packages_path(package, package_arch="arm64"):
     if package_arch == "all":
         package_arch = "amd64"
 
@@ -44,13 +44,13 @@ def packages_path(package, package_arch="armhf"):
     return os.path.join(output_path, basedir, f"{distro}-bullseye-{package_arch}")
 
 
-def package_filename(package_version, package_name, package_arch="armhf"):
+def package_filename(package_version, package_name, package_arch="arm64"):
     return "{name}_{version}_{arch}.deb".format(
         name=package_name, version=package_version, arch=package_arch
     )
 
 
-def package_filename_path(package_version, package_name, package_arch="armhf"):
+def package_filename_path(package_version, package_name, package_arch="arm64"):
     return os.path.join(
         packages_path(package_name, package_arch),
         package_filename(package_version, package_name, package_arch),
@@ -58,7 +58,7 @@ def package_filename_path(package_version, package_name, package_arch="armhf"):
 
 
 def upload_deb_package(
-    ssh_connection, package_version, package_name, package_arch="armhf"
+    ssh_connection, package_version, package_name, package_arch="arm64"
 ):
     ssh_connection.put(
         package_filename_path(package_version, package_name, package_arch)

--- a/tests/test_package_addons.py
+++ b/tests/test_package_addons.py
@@ -36,7 +36,7 @@ class TestPackageAddons:
 
         # Install
         setup_tester_ssh_connection.run(
-            "sudo dpkg --install "
+            "sudo apt -y install --fix-broken ./"
             + package_filename(
                 mender_dist_packages_versions["mender-connect"], "mender-connect"
             )
@@ -63,7 +63,7 @@ class TestPackageAddons:
 
         # Install
         setup_tester_ssh_connection.run(
-            "sudo dpkg --install "
+            "sudo apt -y install --fix-broken ./"
             + package_filename(
                 mender_dist_packages_versions["mender-configure"],
                 "mender-configure",

--- a/tests/test_package_app_update_module.py
+++ b/tests/test_package_app_update_module.py
@@ -50,9 +50,6 @@ class TestPackageMenderAppUpdateModule(PackageMenderAppUpdateModuleChecker):
 
     @pytest.mark.usefixtures("setup_test_container")
     def test_install(self, setup_tester_ssh_connection, mender_dist_packages_versions):
-        result = setup_tester_ssh_connection.run("uname -a")
-        assert "raspberrypi" in result.stdout
-
         upload_deb_package(
             setup_tester_ssh_connection,
             mender_dist_packages_versions["mender-app-update-module"],

--- a/tests/test_package_client_cpp.py
+++ b/tests/test_package_client_cpp.py
@@ -152,11 +152,12 @@ class PackageMenderClientChecker:
         assert result.stdout.split(" ")[0] == expected_copyright_from_l2_md5sum
 
     def check_systemd_service(self, ssh_connection):
-        result = ssh_connection.run("systemctl is-enabled mender-authd")
-        assert result.stdout.strip() == "enabled"
-
-        result = ssh_connection.run("systemctl is-enabled mender-updated")
-        assert result.stdout.strip() == "enabled"
+        ssh_connection.run(
+            "test -f /etc/systemd/system/multi-user.target.wants/mender-authd.service"
+        )
+        ssh_connection.run(
+            "test -f /etc/systemd/system/multi-user.target.wants/mender-updated.service"
+        )
 
 
 @pytest.mark.cppclient
@@ -170,9 +171,6 @@ class TestPackageMenderClientDefaults(PackageMenderClientChecker):
     def test_install_configure_start(
         self, setup_tester_ssh_connection, mender_dist_packages_versions, mender_version
     ):
-        result = setup_tester_ssh_connection.run("uname -a")
-        assert "raspberrypi" in result.stdout
-
         # First things first
         # Explicitly accept suite change from "stable" to "oldstable"
         setup_tester_ssh_connection.run(

--- a/tests/test_package_flash.py
+++ b/tests/test_package_flash.py
@@ -25,9 +25,6 @@ class TestPackageFlash:
 
     @pytest.mark.usefixtures("setup_test_container")
     def test_install(self, setup_tester_ssh_connection, mender_dist_packages_versions):
-        result = setup_tester_ssh_connection.run("uname -a")
-        assert "raspberrypi" in result.stdout
-
         upload_deb_package(
             setup_tester_ssh_connection,
             mender_dist_packages_versions["mender-flash"],

--- a/tests/test_package_setup.py
+++ b/tests/test_package_setup.py
@@ -25,9 +25,6 @@ class TestPackageSetup:
 
     @pytest.mark.usefixtures("setup_test_container")
     def test_install(self, setup_tester_ssh_connection, mender_dist_packages_versions):
-        result = setup_tester_ssh_connection.run("uname -a")
-        assert "raspberrypi" in result.stdout
-
         upload_deb_package(
             setup_tester_ssh_connection,
             mender_dist_packages_versions["mender-setup"],
@@ -51,9 +48,10 @@ class TestPackageSetup:
         assert '"ServerURL": "https://hosted.mender.io"' in result.stdout
 
         # Device type
+        uname_n = setup_tester_ssh_connection.run("uname -n").stdout
         setup_tester_ssh_connection.run("test -f /var/lib/mender/device_type")
         result = setup_tester_ssh_connection.run("cat /var/lib/mender/device_type")
-        assert "device_type=raspberrypi" in result.stdout
+        assert ("device_type=" + uname_n) in result.stdout
 
         result = setup_tester_ssh_connection.run("sudo dpkg --remove mender-setup")
         assert (

--- a/tests/test_package_snapshot.py
+++ b/tests/test_package_snapshot.py
@@ -25,9 +25,6 @@ class TestPackageSnapshot:
 
     @pytest.mark.usefixtures("setup_test_container")
     def test_install(self, setup_tester_ssh_connection, mender_dist_packages_versions):
-        result = setup_tester_ssh_connection.run("uname -a")
-        assert "raspberrypi" in result.stdout
-
         upload_deb_package(
             setup_tester_ssh_connection,
             mender_dist_packages_versions["mender-snapshot"],


### PR DESCRIPTION
Instead of using a dind container running a container running QEMU running ARMv6 Rapberry Pi OS.

TODO: **mender_test_containers revision fixup after merge**

Ticket: QA-1086
Changelog: none