### PR TITLE
feat: use the `device-components` repository

### DIFF
--- a/scripts/install-mender.sh
+++ b/scripts/install-mender.sh
@@ -318,7 +318,7 @@ function get_latest_version_of_commercial_component() {
 }
 
 init() {
-    REPO_URL=https://downloads.mender.io/repos/debian
+    REPO_URL=https://downloads.mender.io/repos/device-components
 
     parse_args "$@"
 


### PR DESCRIPTION
Ticket: None
Changelog: Use the new `device-components` repository for packages. All new device components are published to this repository in favor of the old `debian` repository.