### PR TITLE
ci: clean up unused var

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,8 +51,6 @@ variables:
   S3_BUCKET_REPO_PATH: "invalid"
   # Scripts folder subpath
   S3_BUCKET_SCRIPTS_PATH: "repos/scripts"
-  # GPG key for build, to be set by CI/CD variables
-  GPG_PRIV_KEY_BUILD: ""
   TEST_MENDER_DIST_PACKAGES:
     value: "true"
     options:


### PR DESCRIPTION
The var GPG_PRIV_KEY_BUILD is not used, replaced by MENDER_PRIVATE_GPG_KEY_BUILD

Ticket: QA-791

Linked to: https://github.com/mendersoftware/sre-tools/pull/424