### PR TITLE
ci: Don't build Raspberry Pi OS armhf (ARMv6) packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,13 +101,6 @@ include:
         DISTRO: ubuntu
         RELEASE: [jammy, noble]
         ARCH: [amd64, armhf, arm64]
-.mender-dist-packages-image-matrix-sim:
-  parallel:
-    matrix:
-      - BUILD: simulated
-        DISTRO: raspberrypios
-        RELEASE: [bullseye, bookworm]
-        ARCH: [armhf]
 .mender-dist-packages-workstation_tools-image-matrix-cross:
   parallel:
     matrix:
@@ -259,12 +252,6 @@ build:packages:cross:
       - output/opensource
   parallel: !reference [.mender-dist-packages-image-matrix-cross, parallel]
 
-build:packages:sim:
-  extends: build:packages:cross
-  tags:
-    - hetzner-arm
-  parallel: !reference [.mender-dist-packages-image-matrix-sim, parallel]
-
 build:packages:workstation_tools:cross:
   stage: build:packages
   extends: .build:base
@@ -311,7 +298,6 @@ test:check-python3-formatting:
     # Note that we are only testing packages from Debian bullseye
     - "build:packages:cross: [crosscompile, debian, bullseye, amd64]"
     - "build:packages:workstation_tools:cross: [crosscompile, debian, bullseye, amd64]"
-    - "build:packages:sim: [simulated, raspberrypios, bullseye, armhf]"
     - "build:packages:cross: [crosscompile, debian, bullseye, arm64]"
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
@@ -471,8 +457,6 @@ test:acceptance:workstation_tools:packages:
     - 'build:packages:cross: [crosscompile, ubuntu, noble, armhf]'
     - 'build:packages:cross: [crosscompile, ubuntu, noble, arm64]'
     - 'build:packages:cross: [crosscompile, ubuntu, noble, amd64]'
-    - 'build:packages:sim: [simulated, raspberrypios, bullseye, armhf]'
-    - 'build:packages:sim: [simulated, raspberrypios, bookworm, armhf]'
   stage: publish
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/debian:12
   tags:
@@ -571,8 +555,6 @@ publish:production:s3:scripts:install-mender-sh:
     - 'build:packages:cross: [crosscompile, ubuntu, noble, armhf]'
     - 'build:packages:cross: [crosscompile, ubuntu, noble, arm64]'
     - 'build:packages:cross: [crosscompile, ubuntu, noble, amd64]'
-    - 'build:packages:sim: [simulated, raspberrypios, bullseye, armhf]'
-    - 'build:packages:sim: [simulated, raspberrypios, bookworm, armhf]'
   stage: publish
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/debian:12
   before_script:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Mender is an open source over-the-air (OTA) software updater for embedded Linux 
 
 This repository contains mender-dist-packages, which is used to create distribution packages of the mender client software
 
-Currently only supports creation of a single `.deb` for `arm` architecture suitable for Raspberry Pi 3.
-
 ![Mender logo](https://mender.io/user/pages/resources/06.digital-assets/mender.io.png)
 
 ## Getting started

--- a/docker-build-package
+++ b/docker-build-package
@@ -179,12 +179,6 @@ if [ "$commercial" != "true" -a "$ARCH" = "amd64" ]; then
     BUILD_TYPE="source,${BUILD_TYPE}"
 fi
 
-PLATFORM=""
-
-if [ "$ARCH" = "armhf" -a "$DISTRO" = "raspberrypios" ]; then
-    PLATFORM="--platform=linux/arm/v6"
-fi
-
 echo
 
 docker run --rm \
@@ -196,7 +190,6 @@ docker run --rm \
         --env MENDER_PRIVATE_GPG_KEY_BUILD \
         --env GOLANG_VERSION \
         --env OVERRIDE_DEBIAN_SUFFIX \
-        ${PLATFORM} \
         ${IMAGE_NAME_PREFIX}-${BUILD}-${DISTRO}-${RELEASE}-${ARCH}-${IMAGE_VERSION:-master} \
         /script \
         ${recipe_name} \

--- a/mender-deb-package
+++ b/mender-deb-package
@@ -62,9 +62,6 @@ checkout_repo() {
 install_go() {
   local GOLANG_ARCH=amd64
   local golang_version_set
-  if [ $ARCH = "armhf" -a $OS_DISTRO = "raspbian" ]; then
-    local GOLANG_ARCH=armv6l
-  fi
 
   golang_version_set=$(sed -n '/[^ ]*GOLANG_VERSION:[ "0-9]/{s/.*GOLANG_VERSION:[ ]*\(["0-9\.]*\).*/\1/p;q}' .gitlab-ci.yml)
   golang_version_set=${golang_version_set//\"/}
@@ -107,14 +104,8 @@ get_deb_version() {
   if [ -n "${OVERRIDE_DEBIAN_SUFFIX}" ]; then
     debian_suffix="${OVERRIDE_DEBIAN_SUFFIX}"
   fi
-  if [ $OS_DISTRO = "raspbian" ]; then
-    ################ MEN-7731 Debian armhf packages #####################
-    # For the raspbian builds, use the old "Debian armhf" for the time being. We need to redesign
-    # the APT repositories in order to separate these two armhf builds. Rework this with MEN-7754
-    debian_suffix="$debian_suffix+debian+$OS_CODENAME"
-  else
-    debian_suffix="$debian_suffix+$OS_DISTRO+$OS_CODENAME"
-  fi
+  debian_suffix="$debian_suffix+$OS_DISTRO+$OS_CODENAME"
+
   if [ "$VERSION" != "master" ] && git describe --tags --exact-match 2>/dev/null; then
     DEB_VERSION="$(git describe --tags --exact-match)"
     DEB_VERSION_NO_REV="${DEB_VERSION}"
@@ -234,24 +225,16 @@ build_packages() {
       ;;
 
     armhf)
-      if [ "$OS_DISTRO" = "raspbian" ]; then
-        # Native build (emulated ARM v6)
-        dpkg-buildpackage \
-          ${sign_flags} \
-          ${dpkg_build_ignore_flag} \
-          --build=$DEB_BUILD_TYPE
-      else
-        # Debian ARM 32bit toolchain
-        CROSS_COMPILE="arm-linux-gnueabihf" \
-                     CC="$CROSS_COMPILE-gcc" \
-                     PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig/" \
-                     GOARCH=arm \
-                     dpkg-buildpackage \
-                     --target-arch armhf \
-                     ${sign_flags} \
-                     ${dpkg_build_ignore_flag} \
-                     --build=$DEB_BUILD_TYPE
-      fi
+      # Debian ARM 32bit toolchain
+      CROSS_COMPILE="arm-linux-gnueabihf" \
+                   CC="$CROSS_COMPILE-gcc" \
+                   PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig/" \
+                   GOARCH=arm \
+                   dpkg-buildpackage \
+                   --target-arch armhf \
+                   ${sign_flags} \
+                   ${dpkg_build_ignore_flag} \
+                   --build=$DEB_BUILD_TYPE
       ;;
 
     arm64)


### PR DESCRIPTION
We no longer support ARMv6 packages for Raspberry Pi.

Ticket: QA-1087
Changelog: none