### PR TITLE
chore: Update package build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,87 @@ section in [the Mender documentation](https://docs.mender.io/).
 
 ## Requirements
 
-You need to [install Docker Engine](https://docs.docker.com/install) to use this environment.
+You need to [install Docker Engine](https://docs.docker.com/install) to use this
+environment. Then you need access to the registry.gitlab.com/northern.tech
+container registry:
+
+1. Create a new authentication token for the registry at
+   https://gitlab.com/-/user_settings/personal_access_tokens
+
+2. Log in to the registry:
+
+```bash
+docker login registry.gitlab.com/northern.tech
+```
+
+If you don't have access to the above registry and need to build the container
+images required for builds locally, see the `build.sh` script and `Dockerfile`
+in the [mender-test-containers
+repository](https://github.com/mendersoftware/mender-test-containers/tree/master/mender-dist-packages-building).
+
 
 ### Instructions
 
-To build the Docker image:
+To build the DEB packages, run the `docker-build-package` script as follows:
 
 ```bash
-./docker-build-images
+./docker-build-package build-type distro release arch package-name [version] [save-orig]
 ```
 
-And then build the Debian packages:
+The only supported `build-type` is `crosscompile`. `distro`, `release` and
+`arch` define the target OS. `distro` and `release` can currently be one of the
+following combinations:
+
+- `debian`: `bullseye`, `bookworm`
+- `ubuntu`: `focal`, `jammy`, `noble`
+
+These combinations change in time with new distribution releases and old
+releases going out of support.
+
+The `arch` argument specifies the architecture to build the package(s) for and
+can be one of the following values:
+
+- `armhf`
+- `arm64`
+- `amd64`
+
+The `package-name` and `version` define what should be built. Possible package
+names correspond to the Mender components:
+
+- `mender-app-update-module`
+- `mender-artifact`
+- `mender-cli`
+- `mender-client4`
+- `mender-connect`
+- `mender-configure`
+- `mender-gateway`
+- `mender-flash`
+- `mender-monitor`
+- `mender-setup`
+- `mender-snapshot`
+
+The default value for `version` is `master`. An exact version of a package
+(usually a tag in the component's repository) can be specified. The `version`
+also specifies the version of the recipes used. If there is a recipe for the
+specific `version` in the respective `recipes/$package-name` directory, it is
+used. Otherwise the `debian-master` recipe for the given package is used.
+
+*Note: Some recipes for past versions of various packages can be found in git
+history.*
+
+
+When building the `.orig` tarball (which is needed for building actual `.deb`
+packages), `save-orig` must be set to `true`.
+
+A full example can then be:
 
 ```bash
-./docker-build-package mender-client <version>
-./docker-build-package mender-connect <version>
-./docker-build-package mender-configure <version>
-./docker-build-package mender-gateway <version>
-./docker-build-package mender-monitor <version>
+./docker-build-package crosscompile debian bookworm amd64 mender-flash 1.0.2 true
+./docker-build-package crosscompile debian bookworm amd64 mender-flash 1.0.2
 ```
 
-The deb packages should be ready at output/
+When finished, the packages should be ready in the `output/` directory.
+
 
 ## Contributing
 


### PR DESCRIPTION
The container images are no longer provided and built in this repository and the package building instructions definitely deserve more details.

Ticket: QA-867
Changelog: none