### PR TITLE
chore: Adapt mender-orchestrator-demo to mock interface rename

### DIFF
--- a/recipes/mender-orchestrator-support/debian-master/mender-orchestrator-demo.install
+++ b/recipes/mender-orchestrator-support/debian-master/mender-orchestrator-demo.install
@@ -1,3 +1,3 @@
-/usr/share/mender-orchestrator/interfaces/v1/rtos
+/usr/share/mender-orchestrator/interfaces/v1/rtos-interface
 /data/mender-orchestrator/mock-instances
 /data/mender-orchestrator/topology.yaml


### PR DESCRIPTION
mendersoftware/mender-orchestrator-support@63e0b6ddb02d363a191b033b64d67aa6d265ddf6 renamed the mock interface from `rtos` to `rtos-interface`.

Ticket: MEN-9628
Changelog: none