### PR TITLE
Remove Ubuntu 22 support in favor of new Ubuntu 26 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,7 @@ include:
         RELEASE: [bookworm, trixie]
         ARCH: [amd64, armhf, arm64]
       - DISTRO: ubuntu
-        RELEASE: [jammy, noble]
+        RELEASE: [jammy, noble, resolute]
         ARCH: [amd64, armhf, arm64]
 .mender-dist-packages-workstation_tools-image-matrix-cross:
   parallel:
@@ -203,7 +203,7 @@ include:
         RELEASE: [bookworm, trixie]
         ARCH: [amd64, arm64]
       - DISTRO: ubuntu
-        RELEASE: [jammy, noble]
+        RELEASE: [jammy, noble, resolute]
         ARCH: [amd64, arm64]
 
 .dind-login: &dind-login
@@ -700,6 +700,9 @@ test:pkgs:workstation-tools:trixie:
     - 'build:pkgs:device-components: [ubuntu, noble, armhf]'
     - 'build:pkgs:device-components: [ubuntu, noble, arm64]'
     - 'build:pkgs:device-components: [ubuntu, noble, amd64]'
+    - 'build:pkgs:device-components: [ubuntu, resolute, armhf]'
+    - 'build:pkgs:device-components: [ubuntu, resolute, arm64]'
+    - 'build:pkgs:device-components: [ubuntu, resolute, amd64]'
   stage: publish
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-debian:master
   tags:
@@ -733,6 +736,8 @@ publish:s3:device-components:automatic:
     - 'build:pkgs:workstation-tools: [ubuntu, jammy, arm64]'
     - 'build:pkgs:workstation-tools: [ubuntu, noble, amd64]'
     - 'build:pkgs:workstation-tools: [ubuntu, noble, arm64]'
+    - 'build:pkgs:workstation-tools: [ubuntu, resolute, amd64]'
+    - 'build:pkgs:workstation-tools: [ubuntu, resolute, arm64]'
   stage: publish
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-debian:master
   tags:
@@ -797,6 +802,9 @@ publish:production:s3:scripts:install-mender-sh:
     - 'build:pkgs:device-components: [ubuntu, noble, armhf]'
     - 'build:pkgs:device-components: [ubuntu, noble, arm64]'
     - 'build:pkgs:device-components: [ubuntu, noble, amd64]'
+    - 'build:pkgs:device-components: [ubuntu, resolute, armhf]'
+    - 'build:pkgs:device-components: [ubuntu, resolute, arm64]'
+    - 'build:pkgs:device-components: [ubuntu, resolute, amd64]'
   stage: publish
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-debian:master
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,7 @@ include:
         RELEASE: [bookworm, trixie]
         ARCH: [amd64, armhf, arm64]
       - DISTRO: ubuntu
-        RELEASE: [jammy, noble, resolute]
+        RELEASE: [noble, resolute]
         ARCH: [amd64, armhf, arm64]
 .mender-dist-packages-workstation_tools-image-matrix-cross:
   parallel:
@@ -203,7 +203,7 @@ include:
         RELEASE: [bookworm, trixie]
         ARCH: [amd64, arm64]
       - DISTRO: ubuntu
-        RELEASE: [jammy, noble, resolute]
+        RELEASE: [noble, resolute]
         ARCH: [amd64, arm64]
 
 .dind-login: &dind-login
@@ -694,9 +694,6 @@ test:pkgs:workstation-tools:trixie:
     - 'build:pkgs:device-components: [debian, trixie, amd64]'
     - 'build:pkgs:device-components: [debian, trixie, arm64]'
     - 'build:pkgs:device-components: [debian, trixie, armhf]'
-    - 'build:pkgs:device-components: [ubuntu, jammy, amd64]'
-    - 'build:pkgs:device-components: [ubuntu, jammy, armhf]'
-    - 'build:pkgs:device-components: [ubuntu, jammy, arm64]'
     - 'build:pkgs:device-components: [ubuntu, noble, armhf]'
     - 'build:pkgs:device-components: [ubuntu, noble, arm64]'
     - 'build:pkgs:device-components: [ubuntu, noble, amd64]'
@@ -732,8 +729,6 @@ publish:s3:device-components:automatic:
     - 'build:pkgs:workstation-tools: [debian, bookworm, arm64]'
     - 'build:pkgs:workstation-tools: [debian, trixie, amd64]'
     - 'build:pkgs:workstation-tools: [debian, trixie, arm64]'
-    - 'build:pkgs:workstation-tools: [ubuntu, jammy, amd64]'
-    - 'build:pkgs:workstation-tools: [ubuntu, jammy, arm64]'
     - 'build:pkgs:workstation-tools: [ubuntu, noble, amd64]'
     - 'build:pkgs:workstation-tools: [ubuntu, noble, arm64]'
     - 'build:pkgs:workstation-tools: [ubuntu, resolute, amd64]'
@@ -796,9 +791,6 @@ publish:production:s3:scripts:install-mender-sh:
     - 'build:pkgs:device-components: [debian, trixie, amd64]'
     - 'build:pkgs:device-components: [debian, trixie, arm64]'
     - 'build:pkgs:device-components: [debian, trixie, armhf]'
-    - 'build:pkgs:device-components: [ubuntu, jammy, amd64]'
-    - 'build:pkgs:device-components: [ubuntu, jammy, armhf]'
-    - 'build:pkgs:device-components: [ubuntu, jammy, arm64]'
     - 'build:pkgs:device-components: [ubuntu, noble, armhf]'
     - 'build:pkgs:device-components: [ubuntu, noble, arm64]'
     - 'build:pkgs:device-components: [ubuntu, noble, amd64]'


### PR DESCRIPTION
Add support for Ubuntu 26 and remove support for Ubuntu 22