### PR TITLE
ci: limit build matrix to ubuntu resolute (test)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,20 +190,14 @@ include:
 .mender-dist-packages-image-matrix-cross:
   parallel:
     matrix:
-      - DISTRO: debian
-        RELEASE: [bookworm, trixie]
-        ARCH: [amd64, armhf, arm64]
       - DISTRO: ubuntu
-        RELEASE: [noble, resolute]
+        RELEASE: [resolute]
         ARCH: [amd64, armhf, arm64]
 .mender-dist-packages-workstation_tools-image-matrix-cross:
   parallel:
     matrix:
-      - DISTRO: debian
-        RELEASE: [bookworm, trixie]
-        ARCH: [amd64, arm64]
       - DISTRO: ubuntu
-        RELEASE: [noble, resolute]
+        RELEASE: [resolute]
         ARCH: [amd64, arm64]
 
 .dind-login: &dind-login
@@ -559,24 +553,6 @@ test:check-python3-formatting:
     - source venv/bin/activate
     - PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install -r tests/requirements.txt
 
-test:pkgs:device-components:bookworm:
-  extends: .test:pkgs:device-components
-  needs:
-    - "build:pkgs:device-components: [debian, bookworm, amd64]"
-    - "build:pkgs:device-components: [debian, bookworm, armhf]"
-  variables:
-    DEBIAN_VERSION: 12
-    DEBIAN_VERSION_NAME: "bookworm"
-
-test:pkgs:device-components:trixie:
-  extends: .test:pkgs:device-components
-  needs:
-    - "build:pkgs:device-components: [debian, trixie, amd64]"
-    - "build:pkgs:device-components: [debian, trixie, armhf]"
-  variables:
-    DEBIAN_VERSION: 13
-    DEBIAN_VERSION_NAME: "trixie"
-
 # This template allows testing installation script against different Debian versions
 .test:install-script:
   rules:
@@ -594,26 +570,6 @@ test:pkgs:device-components:trixie:
   artifacts:
     reports:
       junit: scripts/tests/results.xml
-
-test:install-script:bookworm:
-  extends: .test:install-script
-  needs:
-    - "build:pkgs:device-components: [debian, bookworm, amd64]"
-    - "build:pkgs:device-components: [debian, bookworm, armhf]"
-    - "build:pkgs:workstation-tools: [debian, bookworm, amd64]"
-  variables:
-    DEBIAN_VERSION: 12
-    DEBIAN_VERSION_NAME: "bookworm"
-
-test:install-script:trixie:
-  extends: .test:install-script
-  needs:
-    - "build:pkgs:device-components: [debian, trixie, amd64]"
-    - "build:pkgs:device-components: [debian, trixie, armhf]"
-    - "build:pkgs:workstation-tools: [debian, trixie, amd64]"
-  variables:
-    DEBIAN_VERSION: 13
-    DEBIAN_VERSION_NAME: "trixie"
 
 # Legacy tests specific for Debian 11
 # Note that it does not verify built packages (because we don't build anymore for Debian 11)
@@ -658,22 +614,6 @@ test:install-script:legacy:
     - test -x /usr/bin/mender-cli
     - mender-cli --version
 
-test:pkgs:workstation-tools:bookworm:
-  extends: .test:pkgs:workstation-tools
-  variables:
-    DEBIAN_VERSION: 12
-    DEBIAN_VERSION_NAME: "bookworm"
-  needs:
-    - 'build:pkgs:workstation-tools: [debian, bookworm, amd64]'
-
-test:pkgs:workstation-tools:trixie:
-  extends: .test:pkgs:workstation-tools
-  variables:
-    DEBIAN_VERSION: 13
-    DEBIAN_VERSION_NAME: "trixie"
-  needs:
-    - 'build:pkgs:workstation-tools: [debian, trixie, amd64]'
-
 .publish_helper_functions: &publish_helper_functions |
   # Bash function to check if the string is a final tag
   function is_final_tag () {
@@ -688,18 +628,9 @@ test:pkgs:workstation-tools:trixie:
 
 .template:publish:s3:device-components:
   dependencies:
-    - 'build:pkgs:device-components: [debian, bookworm, amd64]'
-    - 'build:pkgs:device-components: [debian, bookworm, arm64]'
-    - 'build:pkgs:device-components: [debian, bookworm, armhf]'
-    - 'build:pkgs:device-components: [debian, trixie, amd64]'
-    - 'build:pkgs:device-components: [debian, trixie, arm64]'
-    - 'build:pkgs:device-components: [debian, trixie, armhf]'
-    - 'build:pkgs:device-components: [ubuntu, noble, armhf]'
-    - 'build:pkgs:device-components: [ubuntu, noble, arm64]'
-    - 'build:pkgs:device-components: [ubuntu, noble, amd64]'
+    - 'build:pkgs:device-components: [ubuntu, resolute, amd64]'
     - 'build:pkgs:device-components: [ubuntu, resolute, armhf]'
     - 'build:pkgs:device-components: [ubuntu, resolute, arm64]'
-    - 'build:pkgs:device-components: [ubuntu, resolute, amd64]'
   stage: publish
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-debian:master
   tags:
@@ -725,12 +656,6 @@ publish:s3:device-components:automatic:
 
 .template:publish:s3:workstation_tools:
   dependencies:
-    - 'build:pkgs:workstation-tools: [debian, bookworm, amd64]'
-    - 'build:pkgs:workstation-tools: [debian, bookworm, arm64]'
-    - 'build:pkgs:workstation-tools: [debian, trixie, amd64]'
-    - 'build:pkgs:workstation-tools: [debian, trixie, arm64]'
-    - 'build:pkgs:workstation-tools: [ubuntu, noble, amd64]'
-    - 'build:pkgs:workstation-tools: [ubuntu, noble, arm64]'
     - 'build:pkgs:workstation-tools: [ubuntu, resolute, amd64]'
     - 'build:pkgs:workstation-tools: [ubuntu, resolute, arm64]'
   stage: publish
@@ -785,18 +710,9 @@ publish:production:s3:scripts:install-mender-sh:
 
 .template:publish:s3:
   dependencies:
-    - 'build:pkgs:device-components: [debian, bookworm, amd64]'
-    - 'build:pkgs:device-components: [debian, bookworm, arm64]'
-    - 'build:pkgs:device-components: [debian, bookworm, armhf]'
-    - 'build:pkgs:device-components: [debian, trixie, amd64]'
-    - 'build:pkgs:device-components: [debian, trixie, arm64]'
-    - 'build:pkgs:device-components: [debian, trixie, armhf]'
-    - 'build:pkgs:device-components: [ubuntu, noble, armhf]'
-    - 'build:pkgs:device-components: [ubuntu, noble, arm64]'
-    - 'build:pkgs:device-components: [ubuntu, noble, amd64]'
+    - 'build:pkgs:device-components: [ubuntu, resolute, amd64]'
     - 'build:pkgs:device-components: [ubuntu, resolute, armhf]'
     - 'build:pkgs:device-components: [ubuntu, resolute, arm64]'
-    - 'build:pkgs:device-components: [ubuntu, resolute, amd64]'
   stage: publish
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-debian:master
   before_script:


### PR DESCRIPTION
Test branch. Reduces both package build matrices to only `ubuntu/resolute` (architectures unchanged) so the pipeline builds just that target.

Changes:
- Both matrices reduced to ubuntu/resolute.
- Removed the 6 debian-only package test jobs whose needs pointed at debian builds that no longer exist.
- Trimmed the publish dependencies lists to the existing ubuntu/resolute build jobs.

Not for merge - throwaway test run.