### PR TITLE
Revert "ci: Mask mender-auth failing test on Ubuntu os"

### DIFF
--- a/tests/test_package_client.py
+++ b/tests/test_package_client.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 
 import pytest
-import os
 
 from helpers import package_filename, upload_deb_package, check_installed
 from mender_test_containers.helpers import *
@@ -219,14 +218,7 @@ class PackageMenderClientChecker:
             assert mender_version in result.stdout
 
     def check_installed_files(self, ssh_connection):
-        try:
-            verify_file_exists(ssh_connection, all_files)
-        except Exception:
-            # This test can fail as on Ubuntu the /usr/share/doc/mender-auth/examples/demo.crt is not being deployed
-            # TODO: Enable this test again on Ubuntu after MEN-9949 is done
-            if os.getenv("OS_FAMILY", "") == "ubuntu":
-                return
-            raise
+        verify_file_exists(ssh_connection, all_files)
         # Northern.tech copyright file
         ssh_connection.run("test -f /usr/share/doc/mender-client4/copyright")
         result = ssh_connection.run(


### PR DESCRIPTION
Implementation in mender repo moved demo.crt from
/usr/share/doc/mender-artifact/examples to
/usr/share/mender-artifact/examples

Thanks to this the test is not failing anymore.

Ticket: MEN-9949

This reverts commit 1e704006265a32d3ac05e3f2b6cf5c6ee4d4caa9.