### PR TITLE
Revert "ci: Mask mender-gateway failing test on Ubuntu os"

### DIFF
--- a/tests/test_package_gateway.py
+++ b/tests/test_package_gateway.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 
 import pytest
-import os
 
 from helpers import package_filename, upload_deb_package, check_installed
 
@@ -45,17 +44,7 @@ class TestPackageGateway:
 
         # Check mender-gateway files
         setup_tester_ssh_connection.run("test -x /usr/bin/mender-gateway")
-        try:
-            setup_tester_ssh_connection.run("test -f /etc/mender/mender-gateway.conf")
-        except Exception:
-            # This test can fail as on Ubuntu the /etc/mender/mender-gateway.conf is a symlink
-            # to /usr/share/doc/mender-gateway/examples/mender-gateway.conf - which is not being
-            # deployed due to mask in /etc/dpkg/dpkg.cfg.d
-            # TODO: Enable this test again on Ubuntu after MEN-9952 is done
-            if os.getenv("OS_FAMILY", "") == "ubuntu":
-                return
-            raise
-
+        setup_tester_ssh_connection.run("test -f /etc/mender/mender-gateway.conf")
         setup_tester_ssh_connection.run(
             "test -f /lib/systemd/system/mender-gateway.service"
         )


### PR DESCRIPTION
Mender gateway has been updated to keep example configuration in /usr/share/mender-gateway/examples

This will result in files no longer being missing after package instal due to dpkg masking.

Ticket: MEN-9952

This reverts commit e72af6af907d69558d5f78e16ac11e3aec84e093.